### PR TITLE
make Gd\Image\supported not choke on uppercase extensions

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -418,7 +418,8 @@ final class Image implements ImageInterface
     private function supported(&$format = null)
     {
         $formats = array('gif', 'jpeg', 'png', 'wbmp', 'xbm');
-
+        $format = strtolower($format);
+        
         if (null === $format) {
             return $formats;
         }


### PR DESCRIPTION
what it says on the tin. No idea if the type needs to be set explicitly for the other backends, or if gmagick/imagick are already tolerant of uppercase.
