### PR TITLE
BC Break: Renamed show() to get()

### DIFF
--- a/lib/Imagine/Filter/Basic/Show.php
+++ b/lib/Imagine/Filter/Basic/Show.php
@@ -37,7 +37,6 @@ class Show implements FilterInterface
      */
     public function apply(ImageInterface $image)
     {
-        echo $image->get($this->format, $this->options);
-        return $image;
+        return $image->show($this->format, $this->options);
     }
 }

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -206,11 +206,31 @@ final class Image implements ImageInterface
      * (non-PHPdoc)
      * @see Imagine\ImageInterface::show()
      */
-    final public function get($format, array $options = array())
+    public function show($format, array $options = array())
+    {
+        $this->saveOrOutput($format, $options);
+
+        return $this;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::get()
+     */
+    public function get($format, array $options = array())
     {
         ob_start();
         $this->saveOrOutput($format, $options);
         return ob_get_clean();
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::__toString()
+     */
+    public function __toString()
+    {
+        return $this->get('png');
     }
 
     /**

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -236,6 +236,17 @@ class Image implements ImageInterface
      * (non-PHPdoc)
      * @see Imagine\ImageInterface::show()
      */
+    public function show($format, array $options = array())
+    {
+        echo $this->get($format, $options);
+
+        return $this;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::get()
+     */
     public function get($format, array $options = array())
     {
         try {
@@ -247,6 +258,15 @@ class Image implements ImageInterface
         }
 
         return (string) $this->gmagick;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::__toString()
+     */
+    public function __toString()
+    {
+        return $this->get('png');
     }
 
     /**

--- a/lib/Imagine/ImageInterface.php
+++ b/lib/Imagine/ImageInterface.php
@@ -105,7 +105,7 @@ interface ImageInterface
     function save($path, array $options = array());
 
     /**
-     * Returns the image content as a binary string
+     * Outputs the image content
      *
      * @param string $format
      * @param array  $options
@@ -114,7 +114,31 @@ interface ImageInterface
      *
      * @return Imagine\ImageInterface
      */
+    function show($format, array $options = array());
+
+    /**
+     * Returns the image content as a binary string
+     *
+     * @param string $format
+     * @param array  $options
+     *
+     * @throws Imagine\Exception\RuntimeException
+     *
+     * @return string binary
+     */
     function get($format, array $options = array());
+
+    /**
+     * Returns the image content as a PNG binary string
+     *
+     * @param string $format
+     * @param array  $options
+     *
+     * @throws Imagine\Exception\RuntimeException
+     *
+     * @return string binary
+     */
+    function __toString();
 
     /**
      * Flips current image using horizontal axis

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -242,6 +242,17 @@ final class Image implements ImageInterface
      * (non-PHPdoc)
      * @see Imagine\ImageInterface::show()
      */
+    public function show($format, array $options = array())
+    {
+        echo $this->get($format, $options);
+
+        return $this;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::get()
+     */
     public function get($format, array $options = array())
     {
         try {
@@ -254,6 +265,15 @@ final class Image implements ImageInterface
         }
 
         return (string) $this->imagick;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see Imagine\ImageInterface::__toString()
+     */
+    public function __toString()
+    {
+        return $this->get('png');
     }
 
     /**

--- a/tests/Imagine/Imagick/ImageTest.php
+++ b/tests/Imagine/Imagick/ImageTest.php
@@ -24,7 +24,7 @@ class ImageTest extends AbstractImageTest
         }
     }
 
-	protected function getImagine()
+    protected function getImagine()
     {
         return new Imagine();
     }


### PR DESCRIPTION
The rationale is that it's much easier to write `echo $image->get();` when you need to echo straight away than it is to write `ob_start();$image->show();ob_get_clean()` when you need the output in a variable. 

Given that in Sf2 you need to populate a Response, it's much easier that way I think. It breaks the chain-ability of it though, but usually get() or save() should be last I guess, so probably not a big deal? The show filter still outputs as it was before.

First commit is unrelated and can be cherry-picked safely btw :)
