### PR TITLE
Add a specific method to create image, add an initial file which permit better alpha support

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -502,7 +502,7 @@ final class Image implements ImageInterface
      *
      * Generates a GD image
      *
-     * @param  Imagine\Image\Box $size
+     * @param  Imagine\Image\BoxInterface $size
      * @param  string the operation initiating the creation
      *
      * @return resource
@@ -510,7 +510,7 @@ final class Image implements ImageInterface
      * @throws RuntimeException
      *
      */
-    private function createImage(Box $size, $operation)
+    private function createImage(BoxInterface $size, $operation)
     {
         $image = imagecreatetruecolor($size->getWidth(), $size->getHeight());
 


### PR DESCRIPTION
The use of image fill after creation permit to conserve alpha channel after copy, resampled ....
imagefill($image, 0, 0, imagecolorallocatealpha($image, 255, 255, 255, 127));

So i have just rewrite the part for alpha support, that i have tested in a a class i created. But as the tests don't work as is, i cannot test the modifications, just reading control.

So by.

With hope this help.
