### PR TITLE
Allow the user to pass a 'format' key in the option array of the save to 

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -186,11 +186,11 @@ final class Image implements ImageInterface
      */
     final public function save($path, array $options = array())
     {
-    	if (!empty($options['format']) && in_array($options['format'], array('jpg', 'png', 'gif'))) {
-    		$extension = $options['format'];
-    	} else {
-    		$extension = pathinfo($path, \PATHINFO_EXTENSION);
-    	}
+        if (!empty($options['format']) && in_array($options['format'], array('jpg', 'png', 'gif'))) {
+            $extension = $options['format'];
+        } else {
+            $extension = pathinfo($path, \PATHINFO_EXTENSION);
+        }
         $this->saveOrOutput($extension, $options, $path);
 
         return $this;


### PR DESCRIPTION
Allow the user to pass a 'format' key in the option array of the save to override the case where you pass a file as a first arg without a file extension. Imagine could not determine the output format in this case and did not process the file.
