### PR TITLE
Changed thumbnail creation mode for Gmagick interface

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -295,9 +295,11 @@ class Image implements ImageInterface
                     true
                 );
             } elseif ($mode === ImageInterface::THUMBNAIL_OUTBOUND) {
-                $thumbnail->gmagick->cropthumbnailimage(
-                    $size->getWidth(),
-                    $size->getHeight()
+                $thumbnail->imagick->thumbnailImage(
+                    $width,
+                    $height,
+                    true,
+                    true
                 );
             }
         } catch (\GmagickException $e) {


### PR DESCRIPTION
I had a problem with cropThumbnailImage returning images with slightly different sizes (e.g. I specified 114x114 but got a resulting image with 113x114). The problem was then that I could not apply an image mask, due to the wrong result size.
Using thumbnailImage instead fixed this.
