### PR TITLE
Changed thumbnail creation mode for Imagick interface

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -303,9 +303,11 @@ final class Image implements ImageInterface
                     true
                 );
             } else if ($mode === ImageInterface::THUMBNAIL_OUTBOUND) {
-                $thumbnail->imagick->cropThumbnailImage(
+                $thumbnail->imagick->thumbnailImage(
                     $width,
-                    $height
+                    $height,
+                    true,
+                    true
                 );
             }
         } catch (\ImagickException $e) {


### PR DESCRIPTION
I had a problem with cropThumbnailImage returning images with slightly different sizes (e.g. I specified 114x114 but got a resulting image with 113x114). The problem was then that I could not apply an image mask, due to the wrong result size.
Using thumbnailImage instead fixed this.
