### PR TITLE
fix crop when using imagick and generating gif images

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -90,6 +90,8 @@ final class Image implements ImageInterface
                 $start->getX(),
                 $start->getY()
             );
+            // Reset canvas for gif format
+            $this->imagick->setImagePage(0, 0, 0, 0);
         } catch (\ImagickException $e) {
             throw new RuntimeException(
                 'Crop operation failed', $e->getCode(), $e


### PR DESCRIPTION
When using Imagick and saving image to GIF format, cropping does not work as expected: generated image has same dimensions as original image, and everything is transparent except cropped zone.

Example:

Original image: large.jpg, in Imagine fixtures.

Code snippet:

``` php
<?php
use Imagine\Imagick\Imagine;
use Imagine\Image\Box;
use Imagine\Image\Point;

$imagine = new Imagine();
$imagine
    ->open('large.jpg')
    ->crop(new Point(250, 40), new Box(150, 150))
    ->show('gif');
```

I expect a 150x150 px image. Here is what I get: http://img580.imageshack.us/img580/6336/imaginecrop.gif

Happens with Imagick 2.2.2 and 3.0.1 (latest stable).
Attached patch tested with these two versions.

Fix found in comments on http://php.net/manual/function.imagick-cropimage.php
