### PR TITLE
fix position for multi-line text

### DIFF
--- a/lib/Imagine/Imagick/Drawer.php
+++ b/lib/Imagine/Imagick/Drawer.php
@@ -354,9 +354,9 @@ final class Drawer implements DrawerInterface
             $sin  = sin($rad);
 
             $x1 = round(0 * $cos - 0 * $sin);
-            $x2 = round($info['textWidth'] * $cos - $info['textHeight'] * $sin);
+            $x2 = round($info['characterWidth'] * $cos - $info['characterHeight'] * $sin);
             $y1 = round(0 * $sin + 0 * $cos);
-            $y2 = round($info['textWidth'] * $sin + $info['textHeight'] * $cos);
+            $y2 = round($info['characterWidth'] * $sin + $info['characterHeight'] * $cos);
 
             $xdiff = 0 - min($x1, $x2);
             $ydiff = 0 - min($y1, $y2);


### PR DESCRIPTION
When calling Imagick\Drawer::text() with a multi-line string, position is not respected: the text is too low. The more line breaks you add, the more your text goes down.

Additionally, with this patch position is more accurate when using angles, even with mono-line strings.

By the way:

``` php
$x1 = round(0 * $cos - 0 * $sin);
$y1 = round(0 * $sin + 0 * $cos);
```

is this code really useful? :-)
