### PR TITLE
Added test for Issue #67.

### DIFF
--- a/tests/Imagine/Issues/Issue67Test.php
+++ b/tests/Imagine/Issues/Issue67Test.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Imagine\Issues;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Box;
+use Imagine\Gd\Imagine;
+use Imagine\Exception\RuntimeException;
+
+class Issue67Test extends \PHPUnit_Framework_TestCase
+{
+    
+    private function getImagine()
+    {
+        try {
+            $imagine = new Imagine();
+        } catch (RuntimeException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+
+        return $imagine;
+    }
+
+    /**
+    * @expectedException Imagine\Exception\RuntimeException
+    */
+    public function testShouldThrowExceptionNotError()
+    {
+        $invalidPath = '/thispathdoesnotexist';
+        
+        $imagine = $this->getImagine();
+
+        $imagine->open('tests/Imagine/Fixtures/large.jpg')
+            ->save($invalidPath . 'myfile.jpg');
+    }
+}


### PR DESCRIPTION
Added a unit test that shows that GD Imagine throws error when saving to invalid folder, not just the exception as expected.
