### PR TITLE
fixed a few essentially cosmetic issues

### DIFF
--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -26,7 +26,6 @@ use Imagine\Filter\Basic\Show;
 use Imagine\Filter\Basic\Thumbnail;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
-use Imagine\ImageFactoryInterface;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Color;
 use Imagine\Image\Fill\FillInterface;

--- a/lib/Imagine/Gd/Drawer.php
+++ b/lib/Imagine/Gd/Drawer.php
@@ -211,8 +211,6 @@ final class Drawer implements DrawerInterface
         $info     = imageftbbox($fontsize, $angle, $fontfile, $string);
         $xs       = array($info[0], $info[2], $info[4], $info[6]);
         $ys       = array($info[1], $info[3], $info[5], $info[7]);
-        $width    = abs(max($xs) - min($xs));
-        $height   = abs(max($ys) - min($ys));
 
         $xdiff = 0 - min($xs) + $position->getX();
         $ydiff = 0 - min($ys) + $position->getY();

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -23,7 +23,6 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Gd\Imagine;
-use Imagine\Mask\MaskInterface;
 
 final class Image implements ImageInterface
 {
@@ -307,6 +306,9 @@ final class Image implements ImageInterface
             $ratio = min($ratios);
         } else if ($mode === ImageInterface::THUMBNAIL_OUTBOUND) {
             $ratio = max($ratios);
+        } else {
+            // TODO: is this the right initialization value?
+            $ratio = 1;
         }
 
         $thumbnailSize = $thumbnail->getSize()->scale($ratio);

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -24,7 +24,6 @@ use Imagine\Image\Fill\Gradient\Vertical;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 use Imagine\Image\ImageInterface;
-use Imagine\Mask\MaskInterface;
 
 final class Image implements ImageInterface
 {

--- a/tests/Imagine/Imagick/ImageTest.php
+++ b/tests/Imagine/Imagick/ImageTest.php
@@ -36,7 +36,6 @@ class ImageTest extends AbstractImageTest
         $imagine = $this->getImagine();
 
         $image = $imagine->open('tests/Imagine/Fixtures/resize/210-design-19933.jpg');
-        $size  = $image->getSize();
 
         $image
             ->resize(new \Imagine\Image\Box(1500, 750))


### PR DESCRIPTION
fixed a few essentially cosmetic issues (except for the missing $ratio init)

btw .. there is one failing test, but it also fails on develop:
There was 1 failure:

1) Imagine\Gd\ImagineTest::testShouldDetermineFontSize
Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
 Imagine\Image\Box Object
 (
-    [width:Imagine\Image\Box:private] => 112
-    [height:Imagine\Image\Box:private] => 46
-    [width:Imagine\Image\Box:private] => 115
-    [height:Imagine\Image\Box:private] => 47
  )

/Users/lsmith/htdocs/symfony-standard/vendor/imagine/tests/Imagine/Image/AbstractImagineTest.php:69
