### PR TITLE
Method clone is deprecated in imagick 3.1.0b1. 

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -60,7 +60,7 @@ final class Image implements ImageInterface
     public function copy()
     {
         try {
-            $clone = $this->imagick->clone();
+            $clone = clone $this->imagick;
         } catch (\ImagickException $e) {
             throw new RuntimeException(
                 'Copy operation failed', $e->getCode(), $e


### PR DESCRIPTION
See http://pecl.php.net/package/imagick/3.1.0b1
