### PR TITLE
Rotating images with Gmagick fails if no background color is set

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -219,6 +219,7 @@ class Image implements ImageInterface
     public function rotate($angle, Color $background = null)
     {
         try {
+            $background = $background ?: new Color('fff');
             $pixel = $this->getColor($background);
 
             $this->gmagick->rotateimage($pixel, $angle);

--- a/tests/Imagine/Image/AbstractImageTest.php
+++ b/tests/Imagine/Image/AbstractImageTest.php
@@ -18,7 +18,20 @@ use Imagine\Test\ImagineTestCase;
 
 abstract class AbstractImageTest extends ImagineTestCase
 {
-    public function testRotate()
+    public function testRotateWithNoBackgroundColor()
+    {
+        $factory = $this->getImagine();
+
+        $image = $factory->open('tests/Imagine/Fixtures/google.png');
+        $image->rotate(90);
+
+        $size = $image->getSize();
+
+        $this->assertSame(126, $size->getWidth());
+        $this->assertSame(364, $size->getHeight());
+    }
+
+    public function testCopyResizedImageToImage()
     {
         $factory = $this->getImagine();
 


### PR DESCRIPTION
The following snippet fails with:

"Catchable fatal error: Argument 1 passed to Imagine\Gmagick\Image::getColor() must be an instance of Imagine\Image\Color, null given"

```
<?php
$imagine = new Imagine\Gmagick\Imagine();
$image = $imagine->open('/path/to/image')->rotate(90);
```

This PR fixes this issue by setting a default background color (the same color set in the Gd implementation).
