### PR TITLE
Uses the clone keyword instead of Imagick::clone

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -60,7 +60,7 @@ final class Image implements ImageInterface
     public function copy()
     {
         try {
-            $clone = $this->imagick->clone();
+            $clone = clone $this->imagick;
         } catch (\ImagickException $e) {
             throw new RuntimeException(
                 'Copy operation failed', $e->getCode(), $e


### PR DESCRIPTION
Imagick::clone() is deprecated as of 3.1.0.
See: http://www.php.net/manual/en/imagick.clone.php
