### PR TITLE
Changing is_file() to fopen()

### DIFF
--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -116,7 +116,7 @@ final class Imagine implements ImagineInterface
      */
     public function open($path)
     {
-        if (!is_file($path)) {
+        if (!fopen($path, "r")) {
             throw new InvalidArgumentException(sprintf(
                 'File %s doesn\'t exist', $path
             ));


### PR DESCRIPTION
 Enables access to external images over http. Eg Files that exist on a CDN.
