### PR TITLE
Suppress PHP warnings when loading invalid images with GD

### DIFF
--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -199,7 +199,7 @@ final class Imagine implements ImagineInterface
      */
     public function load($string)
     {
-        $resource = imagecreatefromstring($string);
+        $resource = @imagecreatefromstring($string);
 
         if (!is_resource($resource)) {
             throw new InvalidArgumentException('An image could not be created from the given input');


### PR DESCRIPTION
This allows us to throw anything at Imagine\Gd\Imagine::load()
and just catch an InvalidArgumentException if it's not a valid image,
without having to worry about it generating PHP warnings.
