### PR TITLE
Fix PNG transparency on save ; do not flatten if not necessary

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -251,7 +251,12 @@ class Image implements ImageInterface
             }
 
             $this->applyImageOptions($this->gmagick, $options);
-            $this->flatten();
+
+            // flatten only if image has multiple layers
+            if ($this->gmagick->hasnextimage() || $this->gmagick->haspreviousimage()) {
+                $this->flatten();
+            }
+
             $this->gmagick->writeimage($path);
         } catch (\GmagickException $e) {
             throw new RuntimeException(

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -242,7 +242,12 @@ final class Image implements ImageInterface
             }
 
             $this->applyImageOptions($this->imagick, $options);
-            $this->flatten();
+
+            // flatten only if image has multiple layers
+            if ($this->imagick->hasNextImage() || $this->imagick->hasPreviousImage()) {
+                $this->flatten();
+            }
+
             $this->imagick->writeImage($path);
         } catch (\ImagickException $e) {
             throw new RuntimeException(


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/romainneutron/Imagine.png?branch=PngTransparency)](http://travis-ci.org/romainneutron/Imagine)

In avalanche123/Imagine#132 I force the flatten operation before saving for all image.

This introduced a bug : PNG with transparent background now got a white background when saving.
This PR fix the introduced bug by checking if the image is multi-layered before flatten it.
