### PR TITLE
Use \Imagick::resizeImage instead of \Imagick::thumbnailImage for resizing

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -187,7 +187,7 @@ final class Image implements ImageInterface
                 'Paste operation failed', $e->getCode(), $e
             );
         }
-        
+
         $this->flatten();
 
         return $this;
@@ -200,7 +200,12 @@ final class Image implements ImageInterface
     public function resize(BoxInterface $size)
     {
         try {
-            $this->imagick->thumbnailImage($size->getWidth(), $size->getHeight());
+            $this->imagick->resizeImage(
+                $size->getWidth(),
+                $size->getHeight(),
+                \Imagick::FILTER_UNDEFINED,
+                1
+            );
         } catch (\ImagickException $e) {
             throw new RuntimeException(
                 'Resize operation failed', $e->getCode(), $e
@@ -513,10 +518,10 @@ final class Image implements ImageInterface
             (int) round($pixel->getColorValue(\Imagick::COLOR_ALPHA) * 100)
         );
     }
-    
+
     /**
      * Internal
-     * 
+     *
      * Flatten the image.
      */
     private function flatten()


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/romainneutron/Imagine.png?branch=ImagickResize)](http://travis-ci.org/romainneutron/Imagine)

`\Imagick::thumbnailImage` strip the image (remove color profiles) for display on the web. It's not the expected behavior.

Switching to the `Imagick::resizeImage` provides a better way to resize and let us the possibility to customize the resize algorithm (in the future). 

---

see differences :
http://www.php.net/manual/en/imagick.thumbnailimage.php
http://www.php.net/manual/en/imagick.resizeimage.php

**note** : 
- Gmagick driver already implement the analog method
- The thumbnail method of the `\Imagine\Image` give the access to the `\Imagick::thumbnailImage` through the  `\Imagine\Image::thumbnail` method
