### PR TITLE
clone()-method is deprecated in current imagick versions

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -60,7 +60,7 @@ final class Image implements ImageInterface
     public function copy()
     {
         try {
-            $clone = $this->imagick->clone();
+            $clone = clone $this->imagick;
         } catch (\ImagickException $e) {
             throw new RuntimeException(
                 'Copy operation failed', $e->getCode(), $e


### PR DESCRIPTION
As stated on http://pecl.php.net/package-changelog.php?package=imagick&release=3.1.0b1, `Imagick::clone()` has been deprecated in favor of `clone $imagick`.
This patch replaces the method with the keyword.
