### PR TITLE
Add docblocks to all classes and interfaces

### DIFF
--- a/lib/Imagine/Draw/DrawerInterface.php
+++ b/lib/Imagine/Draw/DrawerInterface.php
@@ -16,6 +16,9 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\Color;
 use Imagine\Image\PointInterface;
 
+/**
+ * Interface for the drawer
+ */
 interface DrawerInterface
 {
     /**

--- a/lib/Imagine/Effects/EffectsInterface.php
+++ b/lib/Imagine/Effects/EffectsInterface.php
@@ -13,6 +13,9 @@ namespace Imagine\Effects;
 
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Interface for the effects
+ */
 interface EffectsInterface
 {
     /**

--- a/lib/Imagine/Exception/Exception.php
+++ b/lib/Imagine/Exception/Exception.php
@@ -11,6 +11,9 @@
 
 namespace Imagine\Exception;
 
+/**
+ * Imagine-specific exception
+ */
 interface Exception
 {
 }

--- a/lib/Imagine/Exception/InvalidArgumentException.php
+++ b/lib/Imagine/Exception/InvalidArgumentException.php
@@ -13,6 +13,9 @@ namespace Imagine\Exception;
 
 use InvalidArgumentException as BaseInvalidArgumentException;
 
+/**
+ * Imagine-specific invalid argument exception
+ */
 class InvalidArgumentException extends BaseInvalidArgumentException implements Exception
 {
 }

--- a/lib/Imagine/Exception/OutOfBoundsException.php
+++ b/lib/Imagine/Exception/OutOfBoundsException.php
@@ -13,6 +13,9 @@ namespace Imagine\Exception;
 
 use OutOfBoundsException as BaseOutOfBoundsException;
 
+/**
+ * Imagine-specific out of bounds exception
+ */
 class OutOfBoundsException extends BaseOutOfBoundsException implements Exception
 {
 }

--- a/lib/Imagine/Exception/RuntimeException.php
+++ b/lib/Imagine/Exception/RuntimeException.php
@@ -13,6 +13,9 @@ namespace Imagine\Exception;
 
 use RuntimeException as BaseRuntimeException;
 
+/**
+ * Imagine-specific runtime exception
+ */
 class RuntimeException extends BaseRuntimeException implements Exception
 {
 }

--- a/lib/Imagine/Filter/Advanced/Border.php
+++ b/lib/Imagine/Filter/Advanced/Border.php
@@ -16,6 +16,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\Color;
 use Imagine\Image\Point;
 
+/**
+ * A border filter
+ */
 class Border implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Advanced/Canvas.php
+++ b/lib/Imagine/Filter/Advanced/Canvas.php
@@ -19,6 +19,9 @@ use Imagine\Image\PointInterface;
 use Imagine\Image\Color;
 use Imagine\Image\ImagineInterface;
 
+/**
+ * A canvas filter
+ */
 class Canvas implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/ApplyMask.php
+++ b/lib/Imagine/Filter/Basic/ApplyMask.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Filter\FilterInterface;
 use Imagine\Image\ImageInterface;
 
+/**
+ * An apply mask filter
+ */
 class ApplyMask implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Copy.php
+++ b/lib/Imagine/Filter/Basic/Copy.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Filter\FilterInterface;
 use Imagine\Image\ImageInterface;
 
+/**
+ * A copy filter
+ */
 class Copy implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Crop.php
+++ b/lib/Imagine/Filter/Basic/Crop.php
@@ -16,6 +16,9 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\PointInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A crop filter
+ */
 class Crop implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Fill.php
+++ b/lib/Imagine/Filter/Basic/Fill.php
@@ -15,6 +15,9 @@ use Imagine\Filter\FilterInterface;
 use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\ImageInterface;
 
+/**
+ * A fill filter
+ */
 class Fill implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/FlipHorizontally.php
+++ b/lib/Imagine/Filter/Basic/FlipHorizontally.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Image\ImageInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A "flip horizontally" filter
+ */
 class FlipHorizontally implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/FlipVertically.php
+++ b/lib/Imagine/Filter/Basic/FlipVertically.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Image\ImageInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A "flip vertically" filter
+ */
 class FlipVertically implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Paste.php
+++ b/lib/Imagine/Filter/Basic/Paste.php
@@ -15,6 +15,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\PointInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A paste filter
+ */
 class Paste implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Resize.php
+++ b/lib/Imagine/Filter/Basic/Resize.php
@@ -15,6 +15,9 @@ use Imagine\Filter\FilterInterface;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\BoxInterface;
 
+/**
+ * A resize filter
+ */
 class Resize implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Rotate.php
+++ b/lib/Imagine/Filter/Basic/Rotate.php
@@ -15,6 +15,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\Color;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A rotate filter
+ */
 class Rotate implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Save.php
+++ b/lib/Imagine/Filter/Basic/Save.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Image\ImageInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A save filter
+ */
 class Save implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Show.php
+++ b/lib/Imagine/Filter/Basic/Show.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Image\ImageInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A show filter
+ */
 class Show implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Strip.php
+++ b/lib/Imagine/Filter/Basic/Strip.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter\Basic;
 use Imagine\Image\ImageInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A strip filter
+ */
 class Strip implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Basic/Thumbnail.php
+++ b/lib/Imagine/Filter/Basic/Thumbnail.php
@@ -15,6 +15,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\BoxInterface;
 use Imagine\Filter\FilterInterface;
 
+/**
+ * A thumbnail filter
+ */
 class Thumbnail implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/FilterInterface.php
+++ b/lib/Imagine/Filter/FilterInterface.php
@@ -13,6 +13,9 @@ namespace Imagine\Filter;
 
 use Imagine\Image\ImageInterface;
 
+/**
+ * Interface for imagine filters
+ */
 interface FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/ImagineAware.php
+++ b/lib/Imagine/Filter/ImagineAware.php
@@ -14,6 +14,9 @@ namespace Imagine\Filter;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Image\ImagineInterface;
 
+/**
+ * ImagineAware base class
+ */
 abstract class ImagineAware implements FilterInterface
 {
     /**

--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -33,6 +33,9 @@ use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\ManipulatorInterface;
 use Imagine\Image\PointInterface;
 
+/**
+ * A transformation filter
+ */
 final class Transformation implements FilterInterface, ManipulatorInterface
 {
     /**

--- a/lib/Imagine/Gd/Drawer.php
+++ b/lib/Imagine/Gd/Drawer.php
@@ -19,6 +19,9 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\Color;
 use Imagine\Image\PointInterface;
 
+/**
+ * Drawer implementation using the GD library
+ */
 final class Drawer implements DrawerInterface
 {
     /**

--- a/lib/Imagine/Gd/Effects.php
+++ b/lib/Imagine/Gd/Effects.php
@@ -14,6 +14,9 @@ namespace Imagine\Gd;
 use Imagine\Effects\EffectsInterface;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Effects implementation using the GD library
+ */
 class Effects implements EffectsInterface
 {
     private $ressource;

--- a/lib/Imagine/Gd/Font.php
+++ b/lib/Imagine/Gd/Font.php
@@ -14,6 +14,9 @@ namespace Imagine\Gd;
 use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
 
+/**
+ * Font implementation using the GD library
+ */
 final class Font extends AbstractFont
 {
     /**

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -22,6 +22,9 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Image implementation using the GD library
+ */
 final class Image implements ImageInterface
 {
     /**

--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -17,6 +17,9 @@ use Imagine\Image\ImagineInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Imagine implementation using the GD library
+ */
 final class Imagine implements ImagineInterface
 {
     /**

--- a/lib/Imagine/Gmagick/Drawer.php
+++ b/lib/Imagine/Gmagick/Drawer.php
@@ -20,6 +20,9 @@ use Imagine\Image\Color;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 
+/**
+ * Drawer implementation using the Gmagick PHP extension
+ */
 final class Drawer implements DrawerInterface
 {
     /**

--- a/lib/Imagine/Gmagick/Effects.php
+++ b/lib/Imagine/Gmagick/Effects.php
@@ -14,6 +14,9 @@ namespace Imagine\Gmagick;
 use Imagine\Effects\EffectsInterface;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Effects implementation using the Gmagick PHP extension
+ */
 class Effects implements EffectsInterface
 {
     private $gmagick;

--- a/lib/Imagine/Gmagick/Font.php
+++ b/lib/Imagine/Gmagick/Font.php
@@ -15,6 +15,9 @@ use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
 use Imagine\Image\Color;
 
+/**
+ * Font implementation using the Gmagick PHP extension
+ */
 final class Font extends AbstractFont
 {
     /**

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -23,6 +23,9 @@ use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 
+/**
+ * Image implementation using the Gmagick PHP extension
+ */
 class Image implements ImageInterface
 {
     /**

--- a/lib/Imagine/Gmagick/Imagine.php
+++ b/lib/Imagine/Gmagick/Imagine.php
@@ -17,6 +17,9 @@ use Imagine\Image\ImagineInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * Imagine implementation using the Gmagick PHP extension
+ */
 class Imagine implements ImagineInterface
 {
     /**

--- a/lib/Imagine/Image/AbstractFont.php
+++ b/lib/Imagine/Image/AbstractFont.php
@@ -13,6 +13,9 @@ namespace Imagine\Image;
 
 use Imagine\Image\Color;
 
+/**
+ * Abstract font base class
+ */
 abstract class AbstractFont implements FontInterface
 {
     /**

--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -13,6 +13,9 @@ namespace Imagine\Image;
 
 use Imagine\Exception\InvalidArgumentException;
 
+/**
+ * A box implementation
+ */
 final class Box implements BoxInterface
 {
     /**

--- a/lib/Imagine/Image/BoxInterface.php
+++ b/lib/Imagine/Image/BoxInterface.php
@@ -13,6 +13,9 @@ namespace Imagine\Image;
 
 use Imagine\Image\PointInterface;
 
+/**
+ * Interface for a box
+ */
 interface BoxInterface
 {
     /**

--- a/lib/Imagine/Image/Color.php
+++ b/lib/Imagine/Image/Color.php
@@ -13,6 +13,9 @@ namespace Imagine\Image;
 
 use Imagine\Exception\InvalidArgumentException;
 
+/**
+ * The color class
+ */
 final class Color
 {
     /**

--- a/lib/Imagine/Image/Fill/FillInterface.php
+++ b/lib/Imagine/Image/Fill/FillInterface.php
@@ -14,6 +14,9 @@ namespace Imagine\Image\Fill;
 use Imagine\Image\Color;
 use Imagine\Image\PointInterface;
 
+/**
+ * Interface for the fill
+ */
 interface FillInterface
 {
     /**

--- a/lib/Imagine/Image/Fill/Gradient/Horizontal.php
+++ b/lib/Imagine/Image/Fill/Gradient/Horizontal.php
@@ -13,6 +13,9 @@ namespace Imagine\Image\Fill\Gradient;
 
 use Imagine\Image\PointInterface;
 
+/**
+ * Horizontal gradient fill
+ */
 final class Horizontal extends Linear
 {
     /**

--- a/lib/Imagine/Image/Fill/Gradient/Linear.php
+++ b/lib/Imagine/Image/Fill/Gradient/Linear.php
@@ -15,6 +15,9 @@ use Imagine\Image\Color;
 use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\PointInterface;
 
+/**
+ * Linear gradient fill
+ */
 abstract class Linear implements FillInterface
 {
     /**

--- a/lib/Imagine/Image/Fill/Gradient/Vertical.php
+++ b/lib/Imagine/Image/Fill/Gradient/Vertical.php
@@ -13,6 +13,9 @@ namespace Imagine\Image\Fill\Gradient;
 
 use Imagine\Image\PointInterface;
 
+/**
+ * Vertical gradient fill
+ */
 final class Vertical extends Linear
 {
     /**

--- a/lib/Imagine/Image/FontInterface.php
+++ b/lib/Imagine/Image/FontInterface.php
@@ -14,6 +14,9 @@ namespace Imagine\Image;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Color;
 
+/**
+ * The font interface
+ */
 interface FontInterface
 {
     /**

--- a/lib/Imagine/Image/Histogram/Bucket.php
+++ b/lib/Imagine/Image/Histogram/Bucket.php
@@ -11,6 +11,9 @@
 
 namespace Imagine\Image\Histogram;
 
+/**
+ * Bucket histogram
+ */
 final class Bucket implements \Countable
 {
     /**

--- a/lib/Imagine/Image/Histogram/Range.php
+++ b/lib/Imagine/Image/Histogram/Range.php
@@ -13,6 +13,9 @@ namespace Imagine\Image\Histogram;
 
 use Imagine\Exception\OutOfBoundsException;
 
+/**
+ * Range histogram
+ */
 final class Range
 {
     /**

--- a/lib/Imagine/Image/ImageInterface.php
+++ b/lib/Imagine/Image/ImageInterface.php
@@ -18,6 +18,9 @@ use Imagine\Image\Color;
 use Imagine\Image\PointInterface;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * The image interface
+ */
 interface ImageInterface extends ManipulatorInterface
 {
     const RESOLUTION_PIXELSPERINCH = 'ppi';

--- a/lib/Imagine/Image/ImagineInterface.php
+++ b/lib/Imagine/Image/ImagineInterface.php
@@ -18,6 +18,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * The imagine interface
+ */
 interface ImagineInterface
 {
     const VERSION = '0.3.0';

--- a/lib/Imagine/Image/ManipulatorInterface.php
+++ b/lib/Imagine/Image/ManipulatorInterface.php
@@ -19,6 +19,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\PointInterface;
 use Imagine\Image\Fill\FillInterface;
 
+/**
+ * The manipulator interface
+ */
 interface ManipulatorInterface
 {
     const THUMBNAIL_INSET    = 'inset';

--- a/lib/Imagine/Image/Point.php
+++ b/lib/Imagine/Image/Point.php
@@ -13,6 +13,9 @@ namespace Imagine\Image;
 
 use Imagine\Exception\InvalidArgumentException;
 
+/**
+ * The point class
+ */
 final class Point implements PointInterface
 {
     /**

--- a/lib/Imagine/Image/Point/Center.php
+++ b/lib/Imagine/Image/Point/Center.php
@@ -15,6 +15,9 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\Point as OriginalPoint;
 use Imagine\Image\PointInterface;
 
+/**
+ * Point center
+ */
 final class Center implements PointInterface
 {
     /**

--- a/lib/Imagine/Image/PointInterface.php
+++ b/lib/Imagine/Image/PointInterface.php
@@ -14,6 +14,9 @@ namespace Imagine\Image;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\ImageInterface;
 
+/**
+ * The point interface
+ */
 interface PointInterface
 {
     /**

--- a/lib/Imagine/Imagick/Drawer.php
+++ b/lib/Imagine/Imagick/Drawer.php
@@ -20,6 +20,9 @@ use Imagine\Image\Color;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 
+/**
+ * Drawer implementation using the Imagick PHP extension
+ */
 final class Drawer implements DrawerInterface
 {
     /**

--- a/lib/Imagine/Imagick/Effects.php
+++ b/lib/Imagine/Imagick/Effects.php
@@ -13,6 +13,9 @@ namespace Imagine\Imagick;
 
 use Imagine\Effects\EffectsInterface;
 
+/**
+ * Effects implementation using the Imagick PHP extension
+ */
 class Effects implements EffectsInterface
 {
     private $imagick;

--- a/lib/Imagine/Imagick/Font.php
+++ b/lib/Imagine/Imagick/Font.php
@@ -15,6 +15,9 @@ use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
 use Imagine\Image\Color;
 
+/**
+ * Font implementation using the Imagick PHP extension
+ */
 final class Font extends AbstractFont
 {
     /**

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -24,6 +24,9 @@ use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 use Imagine\Image\ImageInterface;
 
+/**
+ * Image implementation using the Imagick PHP extension
+ */
 final class Image implements ImageInterface
 {
     /**

--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -17,6 +17,9 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\ImagineInterface;
 
+/**
+ * Imagine implementation using the Imagick PHP extension
+ */
 final class Imagine implements ImagineInterface
 {
     /**


### PR DESCRIPTION
This is need to work around a PHP bug resulting in a (random?)
docblock being returned when calling getDocComment() on a class
reflection of a class that has no docblock.

See PHP bug 55156. Although reported to be fixed as of 5.3.7 the
test for the bug fails in 5.3.8 (for 5.4.0 the test passes).

The bug then causes errors to be reported by Doctrine's annotation
reader, because it "sees" annotations on classes that don't have
them, and thus lack needed use statements. Bummer.
