### PR TITLE
[Gmagick] call of applyImageOptions before returning binary content

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -291,6 +291,7 @@ class Image implements ImageInterface
     public function get($format, array $options = array())
     {
         try {
+            $this->applyImageOptions($this->gmagick, $options);
             $this->gmagick->setimageformat($format);
         } catch (\GmagickException $e) {
             throw new RuntimeException(


### PR DESCRIPTION
Hi,

The 'get' method now calls `applyImageOptions` before returning the binary content.

This is needed when working only with binary contents and not the `save` method. This way we can easily set options such as quality for instance. For now, there is no way to change the thumbnail output quality without first saving the image to the disk.

Cya
