### PR TITLE
[GD] Drawer::text() position fix

### DIFF
--- a/lib/Imagine/Gd/Drawer.php
+++ b/lib/Imagine/Gd/Drawer.php
@@ -218,27 +218,15 @@ final class Drawer implements DrawerInterface
         $angle    = -1 * $angle;
         $fontsize = $font->getSize();
         $fontfile = $font->getFile();
-        $info     = imageftbbox($fontsize, $angle, $fontfile, $string);
-        $xs       = array($info[0], $info[2], $info[4], $info[6]);
-        $ys       = array($info[1], $info[3], $info[5], $info[7]);
-
-        $xdiff = 0 - min($xs) + $position->getX();
-        $ydiff = 0 - min($ys) + $position->getY();
-
-        foreach ($xs as &$x) {
-            $x += $xdiff;
-        }
-
-        foreach ($ys as &$y) {
-            $y += $ydiff;
-        }
+        $x        = $position->getX();
+        $y        = $position->getY() + $fontsize;
 
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Font mask operation failed');
         }
 
         if (false === imagefttext(
-                $this->resource, $fontsize, $angle, $xs[0], $ys[0],
+                $this->resource, $fontsize, $angle, $x, $y,
                 $this->getColor($font->getColor()), $fontfile, $string
             )) {
             throw new RuntimeException('Font mask operation failed');


### PR DESCRIPTION
When i try drawing multi-line text (line-break with "\n") to a new empty image, y-position of text goes down as count of "\n" in the text. **imagefttext()** function needs x and y coordinates (basepoint of the first character). We already create a Point object for position of text. Just adding fontsize to it and then we can get first character basepoint. I am not sure with this commit but it works for me.
