### PR TITLE
Image interlacing option in GD is supported

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -506,6 +506,10 @@ final class Image implements ImageInterface
         $save = 'image'.$format;
         $args = array(&$this->resource, $filename);
 
+        if (isset($options['interlace'])) {
+            imageinterlace($this->resource, $options['interlace'] ? 1 : 0);
+        }
+
         if (($format === 'jpeg' || $format === 'png') &&
             isset($options['quality'])) {
             // Png compression quality is 0-9, so here we get the value from percent.


### PR DESCRIPTION
Today I read this article: http://calendar.perfplanet.com/2012/progressive-jpegs-a-new-best-practice/ and I realized Imagine is unable to create progressive JPEG images.

To create progressive JPEGs (and not only JPEGs, other formats support this too), interlacing bit has to be set. In PHP this is done via imageinterlace() function  (see http://php.net/manual/en/function.imageinterlace.php#).

I've added option 'interlace' when saving GD images to Imagine\Gd\Image::saveOrOutput() method. The interlace bit is set (or not) according to $options['interlace'] right before calling the saving image*() GD function.
