### PR TITLE
Add travis build on PHP 5.3.3 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+  - 5.3.3
   - 5.3
   - 5.4
+  - 5.5
 script: rake test


### PR DESCRIPTION
Add travis build on PHP 5.5.

Btw, I've added 5.3.3 to ensure BC with common distros lowest denominator (Ubuntu LTS and RedHat)
