### PR TITLE
[WIP][BUGFIX] Improve memory consumption for thumbnails

### DIFF
--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -76,6 +76,30 @@ final class Box implements BoxInterface
     /**
      * {@inheritdoc}
      */
+    public function inset(BoxInterface $targetSize)
+    {
+        $ratio = min(array(
+            $targetSize->getWidth() / $this->getWidth(),
+            $targetSize->getHeight() / $this->getHeight()
+        ));
+        return $this->scale($ratio);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function outbound(BoxInterface $targetSize)
+    {
+        $ratio = max(array(
+            $targetSize->getWidth() / $this->getWidth(),
+            $targetSize->getHeight() / $this->getHeight()
+        ));
+        return $this->scale($ratio);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function increase($size)
     {
         return new Box((int) $size + $this->width, (int) $size + $this->height);

--- a/lib/Imagine/Image/BoxInterface.php
+++ b/lib/Imagine/Image/BoxInterface.php
@@ -42,6 +42,24 @@ interface BoxInterface
     public function scale($ratio);
 
     /**
+     * Creates new BoxInterface with sizes according to inset mode
+     *
+     * @param BoxInterface $targetSize
+     *
+     * @return BoxInterface
+     */
+    public function inset(BoxInterface $targetSize);
+
+    /**
+     * Creates new BoxInterface with sizes according to outbound mode
+     *
+     * @param BoxInterface $targetSize
+     *
+     * @return BoxInterface
+     */
+    public function outbound(BoxInterface $targetSize);
+
+    /**
      * Creates new BoxInterface, adding given size to both sides
      *
      * @param integer $size

--- a/tests/Imagine/Image/AbstractImageTest.php
+++ b/tests/Imagine/Image/AbstractImageTest.php
@@ -46,6 +46,26 @@ abstract class AbstractImageTest extends ImagineTestCase
             );
     }
 
+    /**
+     * @test
+     */
+    public function resizeReturnsSameInstance() {
+        $factory = $this->getImagine();
+        $image = $factory->open('tests/Imagine/Fixtures/google.png');
+        $this->assertSame($image, $image->resize(new Box(200, 200)));
+    }
+
+    /**
+     * @test
+     */
+    public function resizeCreatesNewImageResource() {
+        $factory = $this->getImagine();
+        $image = $factory->open('tests/Imagine/Fixtures/google.png');
+        $imageResource = $this->readAttribute($image, 'resource');
+        $resized = $image->resize(new Box(200, 200));
+        $this->assertAttributeNotSame($imageResource, 'resource', $resized);
+    }
+
     public function testThumbnailGeneration()
     {
         $factory = $this->getImagine();
@@ -68,6 +88,28 @@ abstract class AbstractImageTest extends ImagineTestCase
 
         $this->assertEquals(50, $size->getWidth());
         $this->assertEquals(50, $size->getHeight());
+    }
+
+    /**
+     * @test
+     */
+    public function thumbnailCreatesNewImageInstance() {
+        $factory = $this->getImagine();
+        $image   = $factory->open('tests/Imagine/Fixtures/google.png');
+        $this->assertNotSame($image, $image->thumbnail(new Box(50, 50)));
+    }
+
+    /**
+     * @test
+     */
+    public function thumbnailSetsOriginalAndNewImageInstancesClonedFlag() {
+        $factory = $this->getImagine();
+        $image   = $factory->open('tests/Imagine/Fixtures/google.png');
+        $this->assertAttributeSame(false, 'cloned', $image);
+
+        $thumbnail = $image->thumbnail(new Box(50, 50));
+        $this->assertAttributeSame(true, 'cloned', $image);
+        $this->assertAttributeSame(true, 'cloned', $thumbnail);
     }
 
     public function testCropResizeFlip()
@@ -263,6 +305,13 @@ abstract class AbstractImageTest extends ImagineTestCase
 
     }
 
+    /**
+     * @return \Imagine\Image\ImagineInterface
+     */
     abstract protected function getImagine();
+
+    /**
+     * @return boolean
+     */
     abstract protected function supportMultipleLayers();
 }

--- a/tests/Imagine/Image/BoxTest.php
+++ b/tests/Imagine/Image/BoxTest.php
@@ -124,6 +124,22 @@ class BoxTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Box(100, 200), $box->scale(10));
     }
 
+    /**
+     * @test
+     */
+    public function insetScalesTheBoxCorrectly() {
+        $box = new Box(600, 400);
+        $this->assertEquals(new Box(300, 200), $box->inset(new Box(400, 200)));
+    }
+
+    /**
+     * @test
+     */
+    public function outboundScalesTheBoxCorrectly() {
+        $box = new Box(600, 400);
+        $this->assertEquals(new Box(400, 267), $box->outbound(new Box(400, 200)));
+    }
+
     public function testShouldIncreaseBox()
     {
         $box = new Box(10, 20);


### PR DESCRIPTION
When creating a thumbnail, no longer a copy of the initial,
probably very large image is created, but the resizing
happens directly on the initial image.

For convenience, two new `BoxInterface` methods have been
introduced, `inset()` and `outbound()`, which will provide
an according resizing of a `Box`. The `Image`'s `thumbnail`
method has been refactored to make use of these methods. Credits
go to @noginn for the idea and the code snippet.

Fixes #149
