### PR TITLE
add Imagick getter into Imagick/Image final class

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -61,6 +61,14 @@ final class Image implements ImageInterface
     }
 
     /**
+     * Return imagick instance
+     */
+    public function getImagick()
+    {
+        return $this->imagick;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function copy()


### PR DESCRIPTION
This PR allows people to get imagick instance directly from the final Image instance.

usefull for native imagick getters

see https://github.com/avalanche123/Imagine/issues/207#issuecomment-16159080
