### PR TITLE
phpdoc: copy returns ImageInterface

### DIFF
--- a/lib/Imagine/Image/ManipulatorInterface.php
+++ b/lib/Imagine/Image/ManipulatorInterface.php
@@ -32,7 +32,7 @@ interface ManipulatorInterface
      *
      * @throws RuntimeException
      *
-     * @return ManipulatorInterface
+     * @return ImageInterface
      */
     public function copy();
 


### PR DESCRIPTION
Updated phpdoc for copy method: it actually returns ImageInterface, not ManipulatorInterface
