### PR TITLE
Drawer::text must return $this

### DIFF
--- a/lib/Imagine/Gmagick/Drawer.php
+++ b/lib/Imagine/Gmagick/Drawer.php
@@ -352,6 +352,8 @@ final class Drawer implements DrawerInterface
                 'Draw text operation failed', $e->getCode(), $e
             );
         }
+
+        return $this;
     }
 
     /**

--- a/lib/Imagine/Imagick/Drawer.php
+++ b/lib/Imagine/Imagick/Drawer.php
@@ -384,6 +384,8 @@ final class Drawer implements DrawerInterface
                 'Draw text operation failed', $e->getCode(), $e
             );
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
'return $this' statement is missed in Drawer::text Imagick and Gmagick implementations.
