### PR TITLE
Allow slice image when copy source Image

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -67,10 +67,11 @@ final class Image implements ImageInterface
     /**
      * {@inheritdoc}
      */
-    final public function copy()
+    final public function copy(BoxInterface $size = null)
     {
-        $size = $this->getSize();
-
+        if(!$size) {
+            $size = $this->getSize();
+        }
         $copy = $this->createImage($size, 'copy');
 
         if (false === imagecopy($copy, $this->resource, 0, 0, 0,
@@ -124,12 +125,12 @@ final class Image implements ImageInterface
         }
 
         $size = $image->getSize();
-        //if (!$this->getSize()->contains($size, $start)) {
-        //    throw new OutOfBoundsException(
-        //        'Cannot paste image of the given size at the specified '.
-        //        'position, as it moves outside of the current image\'s box'
-        //    );
-        //}
+        if (!$this->getSize()->contains($size, $start)) {
+            throw new OutOfBoundsException(
+                'Cannot paste image of the given size at the specified '.
+                'position, as it moves outside of the current image\'s box'
+            );
+        }
 
         imagealphablending($this->resource, true);
         imagealphablending($image->resource, true);

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -124,12 +124,12 @@ final class Image implements ImageInterface
         }
 
         $size = $image->getSize();
-        if (!$this->getSize()->contains($size, $start)) {
-            throw new OutOfBoundsException(
-                'Cannot paste image of the given size at the specified '.
-                'position, as it moves outside of the current image\'s box'
-            );
-        }
+        //if (!$this->getSize()->contains($size, $start)) {
+        //    throw new OutOfBoundsException(
+        //        'Cannot paste image of the given size at the specified '.
+        //        'position, as it moves outside of the current image\'s box'
+        //    );
+        //}
 
         imagealphablending($this->resource, true);
         imagealphablending($image->resource, true);

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -71,7 +71,7 @@ final class Image implements ImageInterface
     /**
      * {@inheritdoc}
      */
-    public function copy()
+    public function copy(BoxInterface $size = null)
     {
         return new self(clone $this->gmagick);
     }

--- a/lib/Imagine/Image/ManipulatorInterface.php
+++ b/lib/Imagine/Image/ManipulatorInterface.php
@@ -30,11 +30,12 @@ interface ManipulatorInterface
     /**
      * Copies current source image into a new ImageInterface instance
      *
+     * @param BoxInterface   $size
      * @throws RuntimeException
      *
      * @return ManipulatorInterface
      */
-    public function copy();
+    public function copy(BoxInterface $size = null);
 
     /**
      * Crops a specified box out of the source image (modifies the source image)


### PR DESCRIPTION
Defining an optional $size parameter in copy function i can create a new image with new size. Useful for image slice without resizing.
