### PR TITLE
Fix default RGB profile to get better color conversion

### DIFF
--- a/lib/Imagine/Image/Palette/RGB.php
+++ b/lib/Imagine/Image/Palette/RGB.php
@@ -84,7 +84,7 @@ class RGB implements PaletteInterface
     {
         if (!$this->profile) {
             $this->profile = Profile::fromPath(
-                __DIR__ . '/../../resources/Adobe/RGB/AdobeRGB1998.icc'
+                __DIR__ . '/../../resources/color.org/sRGB_IEC61966-2-1_black_scaled.icc'
             );
         }
 

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -548,7 +548,7 @@ abstract class AbstractImageTest extends ImagineTestCase
             ->strip()
             ->getColorAt(new Point(0, 0));
 
-        $this->assertEquals('#30819f', (string) $color);
+        $this->assertEquals('#0082a2', (string) $color);
     }
 
     public function testStripGBRImageHasGoodColors()
@@ -559,7 +559,7 @@ abstract class AbstractImageTest extends ImagineTestCase
             ->strip()
             ->getColorAt(new Point(0, 0));
 
-        $this->assertEquals('#bb7461', (string) $color);
+        $this->assertEquals('#d07560', (string) $color);
     }
 
     private function getMonoLayeredImage()


### PR DESCRIPTION
After using the develop branch a lot, I realized the colors provided with the default RGB palette were not right compared to color conversion Photoshop could do.

Using this already bundled profile by default provides a much more better color conversion when getting RGB image from CMYK image and RGB with custom profiles.
