### PR TITLE
Add support for images that have a height or width of 0.*px

### DIFF
--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -38,15 +38,15 @@ final class Box implements BoxInterface
      */
     public function __construct($width, $height)
     {
-        if ($height < 1 || $width < 1) {
+        if ($height <= 0 || $width <= 0) {
             throw new InvalidArgumentException(sprintf(
                 'Length of either side cannot be 0 or negative, current size '.
                 'is %sx%s', $width, $height
             ));
         }
 
-        $this->width  = (int) $width;
-        $this->height = (int) $height;
+        $this->width  = (int) max($width, 1);
+        $this->height = (int) max($height, 1);
     }
 
     /**


### PR DESCRIPTION
Check if the dimension is less than or equal to 0, not less than 1 as there are images that are 0.\* pixels wide or high and they are still valid.
