### PR TITLE
create BoxFactoryInterface to provide a easy way to change Box class imp...

### DIFF
--- a/lib/Imagine/Gd/Font.php
+++ b/lib/Imagine/Gd/Font.php
@@ -13,6 +13,7 @@ namespace Imagine\Gd;
 
 use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Font implementation using the GD library
@@ -31,6 +32,6 @@ final class Font extends AbstractFont
         $width    = abs(max($xs) - min($xs));
         $height   = abs(max($ys) - min($ys));
 
-        return new Box($width, $height);
+        return $this->getBoxFactory()->create($width, $height);
     }
 }

--- a/lib/Imagine/Gd/Font.php
+++ b/lib/Imagine/Gd/Font.php
@@ -32,6 +32,6 @@ final class Font extends AbstractFont
         $width    = abs(max($xs) - min($xs));
         $height   = abs(max($ys) - min($ys));
 
-        return $this->getBoxFactory()->create($width, $height);
+        return $this->getBoxFactory()->createBox($width, $height);
     }
 }

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -361,7 +361,7 @@ final class Image extends AbstractImage
      */
     public function getSize()
     {
-        return $this->getBoxFactory()->create(imagesx($this->resource), imagesy($this->resource));
+        return $this->getBoxFactory()->createBox(imagesx($this->resource), imagesy($this->resource));
     }
 
     /**

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -26,6 +26,7 @@ use Imagine\Image\Palette\RGB;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Image implementation using the GD library
@@ -58,11 +59,14 @@ final class Image extends AbstractImage
      * @param resource         $resource
      * @param PaletteInterface $palette
      */
-    public function __construct($resource, PaletteInterface $palette, $path = null)
+    public function __construct($resource, PaletteInterface $palette, $path = null, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->palette = $palette;
         $this->resource = $resource;
         $this->path = $path;
+
+        $this->setBoxFactory($boxFactory);
     }
 
     /**
@@ -357,7 +361,7 @@ final class Image extends AbstractImage
      */
     public function getSize()
     {
-        return new Box(imagesx($this->resource), imagesy($this->resource));
+        return $this->getBoxFactory()->create(imagesx($this->resource), imagesy($this->resource));
     }
 
     /**

--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -19,6 +19,8 @@ use Imagine\Image\ImagineInterface;
 use Imagine\Image\Palette\Color\RGB as RGBColor;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
+use Imagine\Image\BoxFactoryInterface;
+use Imagine\Image\BoxFactory;
 
 /**
  * Imagine implementation using the GD library
@@ -29,14 +31,21 @@ final class Imagine implements ImagineInterface
      * @var array
      */
     private $info;
+    
+    /**
+     * @var BoxFactoryInterface
+     */
+    private $boxFactory;
 
     /**
      * @throws RuntimeException
      */
-    public function __construct()
+    public function __construct(BoxFactoryInterface $boxFactory = null)
     {
         $this->loadGdInfo();
         $this->requireGdVersion('2.0.1');
+        
+        $this->boxFactory = $boxFactory ?: BoxFactory::instance();
     }
 
     private function loadGdInfo()
@@ -161,7 +170,7 @@ final class Imagine implements ImagineInterface
             throw new RuntimeException('GD is not compiled with FreeType support');
         }
 
-        return new Font($file, $size, $color);
+        return new Font($file, $size, $color, $this->boxFactory);
     }
 
     private function wrap($resource, PaletteInterface $palette, $path = null)
@@ -193,6 +202,6 @@ final class Imagine implements ImagineInterface
             imageantialias($resource, true);
         }
 
-        return new Image($resource, $palette, $path);
+        return new Image($resource, $palette, $path, $this->boxFactory);
     }
 }

--- a/lib/Imagine/Gmagick/Font.php
+++ b/lib/Imagine/Gmagick/Font.php
@@ -58,7 +58,7 @@ final class Font extends AbstractFont
 
         $info = $this->gmagick->queryfontmetrics($text, $string);
 
-        $box = $this->getBoxFactory()->create($info['textWidth'], $info['textHeight']);
+        $box = $this->getBoxFactory()->createBox($info['textWidth'], $info['textHeight']);
 
         return $box;
     }

--- a/lib/Imagine/Gmagick/Font.php
+++ b/lib/Imagine/Gmagick/Font.php
@@ -14,6 +14,7 @@ namespace Imagine\Gmagick;
 use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Font implementation using the Gmagick PHP extension
@@ -31,11 +32,12 @@ final class Font extends AbstractFont
      * @param integer        $size
      * @param ColorInterface $color
      */
-    public function __construct(\Gmagick $gmagick, $file, $size, ColorInterface $color)
+    public function __construct(\Gmagick $gmagick, $file, $size, ColorInterface $color, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->gmagick = $gmagick;
 
-        parent::__construct($file, $size, $color);
+        parent::__construct($file, $size, $color, $boxFactory);
     }
 
     /**
@@ -56,7 +58,7 @@ final class Font extends AbstractFont
 
         $info = $this->gmagick->queryfontmetrics($text, $string);
 
-        $box = new Box($info['textWidth'], $info['textHeight']);
+        $box = $this->getBoxFactory()->create($info['textWidth'], $info['textHeight']);
 
         return $box;
     }

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -24,6 +24,7 @@ use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
 use Imagine\Image\ProfileInterface;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Image implementation using the Gmagick PHP extension
@@ -55,11 +56,14 @@ final class Image extends AbstractImage
      * @param \Gmagick         $gmagick
      * @param PaletteInterface $palette
      */
-    public function __construct(\Gmagick $gmagick, PaletteInterface $palette)
+    public function __construct(\Gmagick $gmagick, PaletteInterface $palette, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->gmagick = $gmagick;
         $this->setColorspace($palette);
         $this->layers = new Layers($this, $this->palette, $this->gmagick);
+        
+        $this->setBoxFactory($boxFactory);
     }
 
     /**
@@ -420,7 +424,7 @@ final class Image extends AbstractImage
             );
         }
 
-        return new Box($width, $height);
+        return $this->getBoxFactory()->create($width, $height);
     }
 
     /**

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -424,7 +424,7 @@ final class Image extends AbstractImage
             );
         }
 
-        return $this->getBoxFactory()->create($width, $height);
+        return $this->getBoxFactory()->createBox($width, $height);
     }
 
     /**

--- a/lib/Imagine/Image/AbstractFont.php
+++ b/lib/Imagine/Image/AbstractFont.php
@@ -32,6 +32,8 @@ abstract class AbstractFont implements FontInterface
      * @var ColorInterface
      */
     protected $color;
+    
+    private $boxFactory;
 
     /**
      * Constructs a font with specified $file, $size and $color
@@ -42,11 +44,13 @@ abstract class AbstractFont implements FontInterface
      * @param integer        $size
      * @param ColorInterface $color
      */
-    public function __construct($file, $size, ColorInterface $color)
+    public function __construct($file, $size, ColorInterface $color, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->file  = $file;
         $this->size  = $size;
         $this->color = $color;
+        $this->boxFactory = $boxFactory;
     }
 
     /**
@@ -71,5 +75,18 @@ abstract class AbstractFont implements FontInterface
     final public function getColor()
     {
         return $this->color;
+    }
+        
+    /**
+     * @return BoxFactoryInterface
+     */
+    final protected function getBoxFactory()
+    {
+        if ($this->boxFactory === null)
+        {
+            $this->boxFactory = BoxFactory::instance();
+        }
+        
+        return $this->boxFactory;
     }
 }

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -15,6 +15,26 @@ use Imagine\Exception\InvalidArgumentException;
 
 abstract class AbstractImage implements ImageInterface
 {
+    private $boxFactory;
+    
+    /**
+     * @return BoxFactoryInterface
+     */
+    final protected function getBoxFactory()
+    {
+        if ($this->boxFactory === null)
+        {
+            $this->boxFactory = BoxFactory::instance();
+        }
+        
+        return $this->boxFactory;
+    }
+    
+    final protected function setBoxFactory(BoxFactoryInterface $boxFactory = null)
+    {
+        $this->boxFactory = $boxFactory;
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/lib/Imagine/Image/BoxFactory.php
+++ b/lib/Imagine/Image/BoxFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Image;
+
+/**
+ * Default implementation fo box factory
+ */
+final class BoxFactory implements BoxFactoryInterface
+{
+    private static $instance;
+    
+    /**
+     * @return BoxFactory
+     */
+    public static function instance()
+    {
+        if(self::$instance === null)
+        {
+            self::$instance = new self();
+        }
+        
+        return self::$instance;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function create($width, $height)
+    {
+        return new Box($width, $height);
+    }
+}

--- a/lib/Imagine/Image/BoxFactory.php
+++ b/lib/Imagine/Image/BoxFactory.php
@@ -34,7 +34,7 @@ final class BoxFactory implements BoxFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($width, $height)
+    public function createBox($width, $height)
     {
         return new Box($width, $height);
     }

--- a/lib/Imagine/Image/BoxFactoryInterface.php
+++ b/lib/Imagine/Image/BoxFactoryInterface.php
@@ -25,5 +25,5 @@ interface BoxFactoryInterface
      * @return BoxInterface
      * @throws InvalidArgumentException
      */
-    public function create($width, $height);
+    public function createBox($width, $height);
 }

--- a/lib/Imagine/Image/BoxFactoryInterface.php
+++ b/lib/Imagine/Image/BoxFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Image;
+
+/**
+ * Interface for box factory
+ */
+interface BoxFactoryInterface
+{
+    /**
+     * Creates box with given size
+     * 
+     * @param integer $width
+     * @param integer $height
+     * 
+     * @return BoxInterface
+     * @throws InvalidArgumentException
+     */
+    public function create($width, $height);
+}

--- a/lib/Imagine/Imagick/Font.php
+++ b/lib/Imagine/Imagick/Font.php
@@ -64,7 +64,7 @@ final class Font extends AbstractFont
 
         $info = $this->imagick->queryFontMetrics($text, $string);
 
-        $box = $this->getBoxFactory()->create($info['textWidth'], $info['textHeight']);
+        $box = $this->getBoxFactory()->createBox($info['textWidth'], $info['textHeight']);
 
         return $box;
     }

--- a/lib/Imagine/Imagick/Font.php
+++ b/lib/Imagine/Imagick/Font.php
@@ -14,6 +14,7 @@ namespace Imagine\Imagick;
 use Imagine\Image\AbstractFont;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Font implementation using the Imagick PHP extension
@@ -26,16 +27,18 @@ final class Font extends AbstractFont
     private $imagick;
 
     /**
-     * @param \Imagick       $imagick
-     * @param string         $file
-     * @param integer        $size
-     * @param ColorInterface $color
+     * @param \Imagick            $imagick
+     * @param string              $file
+     * @param integer             $size
+     * @param ColorInterface      $color
+     * @param BoxFactoryInterface $boxFactory
      */
-    public function __construct(\Imagick $imagick, $file, $size, ColorInterface $color)
+    public function __construct(\Imagick $imagick, $file, $size, ColorInterface $color, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->imagick = $imagick;
 
-        parent::__construct($file, $size, $color);
+        parent::__construct($file, $size, $color, $boxFactory);
     }
 
     /**
@@ -61,7 +64,7 @@ final class Font extends AbstractFont
 
         $info = $this->imagick->queryFontMetrics($text, $string);
 
-        $box = new Box($info['textWidth'], $info['textHeight']);
+        $box = $this->getBoxFactory()->create($info['textWidth'], $info['textHeight']);
 
         return $box;
     }

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -441,7 +441,7 @@ final class Image extends AbstractImage
             );
         }
 
-        return $this->getBoxFactory()->create($width, $height);
+        return $this->getBoxFactory()->createBox($width, $height);
     }
 
     /**

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -26,6 +26,7 @@ use Imagine\Image\PointInterface;
 use Imagine\Image\ProfileInterface;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Palette\PaletteInterface;
+use Imagine\Image\BoxFactoryInterface;
 
 /**
  * Image implementation using the Imagick PHP extension
@@ -59,10 +60,12 @@ final class Image extends AbstractImage
     /**
      * Constructs Image with Imagick and Imagine instances
      *
-     * @param \Imagick         $imagick
-     * @param PaletteInterface $palette
+     * @param \Imagick            $imagick
+     * @param PaletteInterface    $palette
+     * @param BoxFactoryInterface $boxFactory
      */
-    public function __construct(\Imagick $imagick, PaletteInterface $palette)
+    public function __construct(\Imagick $imagick, PaletteInterface $palette, 
+            BoxFactoryInterface $boxFactory = null)
     {
         $this->detectColorspaceConversionSupport();
         $this->imagick = $imagick;
@@ -71,6 +74,8 @@ final class Image extends AbstractImage
         }
         $this->palette = $palette;
         $this->layers = new Layers($this, $this->palette, $this->imagick);
+        
+        $this->setBoxFactory($boxFactory);
     }
 
     /**
@@ -436,7 +441,7 @@ final class Image extends AbstractImage
             );
         }
 
-        return new Box($width, $height);
+        return $this->getBoxFactory()->create($width, $height);
     }
 
     /**


### PR DESCRIPTION
Imagine library has `BoxInterface` interface but there are no way to change implementation that is used by Imagine. In my library that depends on Imagine I would like to change `Box` implementation, but there are no clean way to achieve this. So I have provided `BoxFactoryInterface` that can be injected to Imagine object. There are no any BC.
