### PR TITLE
add resampling filter option when changing resolution

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -908,7 +908,10 @@ final class Image extends AbstractImage
         );
 
         if (!array_key_exists($filter, $supportedFilters)) {
-            throw new InvalidArgumentException('Unsupported filter type');
+            throw new InvalidArgumentException(sprintf(
+                'The resampling filter "%s" is not supported by Imagick driver.',
+                $filter
+            ));
         }
 
         return $supportedFilters[$filter];


### PR DESCRIPTION
Hi there, I'm wondering, whether there is a proper way with imagine scaling SVG images (no SMIL etc. contained) and writing it back e.g. as JPEG.

When using Imagick directly, I end up with this code. Is there any supported way utilizing Imagine, is it even within the scope of Imagine?

``` php
class ImageTest extends \PHPUnit_Framework_TestCase
{
    protected static $fixtureDirectory;
    protected static $temporaryDirectory;

    public static function setUpBeforeClass()
    {
        self::$fixtureDirectory = __DIR__ . '/../../DataFixtures/Files';
        self::$temporaryDirectory = sys_get_temp_dir();
    }

    public function testImagickSvg()
    {
        $input = self::$fixtureDirectory . DIRECTORY_SEPARATOR . 'example.svg';
        $output = self::$temporaryDirectory . DIRECTORY_SEPARATOR . 'output.jpg';

        $expectedWidth = 720;
        $expectedHeight = 200;

        $image = new \Imagick();
        $image->setResolution($expectedWidth * 4, $expectedHeight * 4);
        $image->setBackgroundColor(new \ImagickPixel('white'));
        $image->readImage($input);
        $image->scaleImage($expectedWidth, $expectedHeight);
        $image->setImageFormat('jpeg');
        $image->writeimage($output);

        $this->assertDimensions($expectedWidth, $expectedHeight, $output);
    }

    /**
     * Assert that the dimensions of the given output file match the expected values.
     *
     * @param int    $expectedWidth
     * @param int    $expectedHeight
     * @param string $output         The image file to verify.
     */
    public static function assertDimensions($expectedWidth, $expectedHeight, $output)
    {
        list($width, $height) = getimagesize($output);

        self::assertEquals($expectedWidth, $width, 'The expected image width does not match.');
        self::assertEquals($expectedHeight, $height, 'The expected image height does not match.');
    }
}
```
