### PR TITLE
Add normalizeFormat() method in GD driver

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -559,7 +559,7 @@ final class Image extends AbstractImage
         if (!$this->supported($format)) {
             throw new InvalidArgumentException(sprintf(
                 'Saving image in "%s" format is not supported, please use one '.
-                'of the following extension: "%s"', $format,
+                'of the following extensions: "%s"', $format,
                 implode('", "', $this->supported())
             ));
         }
@@ -749,7 +749,6 @@ final class Image extends AbstractImage
 
         static $mimeTypes = array(
             'jpeg' => 'image/jpeg',
-            'jpg'  => 'image/jpeg',
             'gif'  => 'image/gif',
             'png'  => 'image/png',
             'wbmp' => 'image/vnd.wap.wbmp',


### PR DESCRIPTION
Makes code less confusing by separating concerns (and avoiding pass-by-reference).
