### PR TITLE
Fix #320: ImagineInterface::open now accepts any string castable object as argument

### DIFF
--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -83,6 +83,7 @@ final class Imagine extends AbstractImagine
      */
     public function open($path)
     {
+        $path = $this->checkPath($path);
         $data = @file_get_contents($path);
 
         if (false === $data) {

--- a/lib/Imagine/Gmagick/Imagine.php
+++ b/lib/Imagine/Gmagick/Imagine.php
@@ -43,13 +43,7 @@ class Imagine extends AbstractImagine
      */
     public function open($path)
     {
-        $handle = @fopen($path, 'r');
-
-        if (false === $handle) {
-            throw new InvalidArgumentException(sprintf('File %s doesn\'t exist', $path));
-        }
-
-        fclose($handle);
+        $path = $this->checkPath($path);
 
         try {
             $gmagick = new \Gmagick($path);

--- a/lib/Imagine/Image/AbstractImagine.php
+++ b/lib/Imagine/Image/AbstractImagine.php
@@ -42,4 +42,32 @@ abstract class AbstractImagine implements ImagineInterface
 
         return $this->metadataReader;
     }
+
+    /**
+     * Checks a path that could be used with ImagineInterface::open and returns
+     * a proper string.
+     *
+     * @param string|object $path
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException In case the given path is invalid.
+     */
+    protected function checkPath($path)
+    {
+        // provide compatibility with objects such as \SplFileInfo
+        if (is_object($path) && method_exists($path, '__toString')) {
+            $path = (string) $path;
+        }
+
+        $handle = @fopen($path, 'r');
+
+        if (false === $handle) {
+            throw new InvalidArgumentException(sprintf('File %s doesn\'t exist', $path));
+        }
+
+        fclose($handle);
+
+        return $path;
+    }
 }

--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -50,13 +50,7 @@ final class Imagine extends AbstractImagine
      */
     public function open($path)
     {
-        $handle = @fopen($path, 'r');
-
-        if (false === $handle) {
-            throw new InvalidArgumentException(sprintf('File %s doesn\'t exist', $path));
-        }
-
-        fclose($handle);
+        $path = $this->checkPath($path);
 
         try {
             $imagick = new \Imagick($path);

--- a/tests/Imagine/Test/Image/AbstractImagineTest.php
+++ b/tests/Imagine/Test/Image/AbstractImagineTest.php
@@ -47,6 +47,24 @@ abstract class AbstractImagineTest extends ImagineTestCase
         $this->assertEquals(realpath($source), $metadata['filepath']);
     }
 
+    public function testShouldOpenAnSplFileResource()
+    {
+        $source = 'tests/Imagine/Fixtures/google.png';
+        $resource = new \SplFileInfo($source);
+        $factory = $this->getImagine();
+        $image   = $factory->open($resource);
+        $size    = $image->getSize();
+
+        $this->assertInstanceOf('Imagine\Image\ImageInterface', $image);
+        $this->assertEquals(364, $size->getWidth());
+        $this->assertEquals(126, $size->getHeight());
+
+        $metadata = $image->metadata();
+
+        $this->assertEquals($source, $metadata['uri']);
+        $this->assertEquals(realpath($source), $metadata['filepath']);
+    }
+
     public function testShouldOpenAnHttpImage()
     {
         $factory = $this->getImagine();


### PR DESCRIPTION
This revert compatibility with SplFileInfo objects.
