### PR TITLE
Make Imagine more hackable, remove final keywords from classes and functions declaration

### DIFF
--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -36,7 +36,7 @@ use Imagine\Image\PointInterface;
 /**
  * A transformation filter
  */
-final class Transformation implements FilterInterface, ManipulatorInterface
+class Transformation implements FilterInterface, ManipulatorInterface
 {
     /**
      * @var array

--- a/lib/Imagine/Gd/Drawer.php
+++ b/lib/Imagine/Gd/Drawer.php
@@ -23,7 +23,7 @@ use Imagine\Image\PointInterface;
 /**
  * Drawer implementation using the GD library
  */
-final class Drawer implements DrawerInterface
+class Drawer implements DrawerInterface
 {
     /**
      * @var resource

--- a/lib/Imagine/Gd/Font.php
+++ b/lib/Imagine/Gd/Font.php
@@ -18,7 +18,7 @@ use Imagine\Image\Box;
 /**
  * Font implementation using the GD library
  */
-final class Font extends AbstractFont
+class Font extends AbstractFont
 {
     /**
      * {@inheritdoc}

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -31,7 +31,7 @@ use Imagine\Exception\RuntimeException;
 /**
  * Image implementation using the GD library
  */
-final class Image extends AbstractImage
+class Image extends AbstractImage
 {
     /**
      * @var resource
@@ -85,7 +85,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function copy()
+    public function copy()
     {
         $size = $this->getSize();
         $copy = $this->createImage($size, 'copy');
@@ -100,7 +100,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function crop(PointInterface $start, BoxInterface $size)
+    public function crop(PointInterface $start, BoxInterface $size)
     {
         if (!$start->in($this->getSize())) {
             throw new OutOfBoundsException('Crop coordinates must start at minimum 0, 0 position from top  left corner, crop height and width must be positive integers and must not exceed the current image borders');
@@ -125,7 +125,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function paste(ImageInterface $image, PointInterface $start)
+    public function paste(ImageInterface $image, PointInterface $start)
     {
         if (!$image instanceof self) {
             throw new InvalidArgumentException(sprintf('Gd\Image can only paste() Gd\Image instances, %s given', get_class($image)));
@@ -152,7 +152,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
+    public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {
         if (ImageInterface::FILTER_UNDEFINED !== $filter) {
             throw new InvalidArgumentException('Unsupported filter type, GD only supports ImageInterface::FILTER_UNDEFINED filter');
@@ -183,7 +183,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function rotate($angle, ColorInterface $background = null)
+    public function rotate($angle, ColorInterface $background = null)
     {
         $color = $background ? $background : $this->palette->color('fff');
         $resource = imagerotate($this->resource, -1 * $angle, $this->getColor($color));
@@ -201,7 +201,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function save($path = null, array $options = array())
+    public function save($path = null, array $options = array())
     {
         $path = null === $path ? (isset($this->metadata['filepath']) ? $this->metadata['filepath'] : $path) : $path;
 
@@ -257,7 +257,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function flipHorizontally()
+    public function flipHorizontally()
     {
         $size   = $this->getSize();
         $width  = $size->getWidth();
@@ -280,7 +280,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function flipVertically()
+    public function flipVertically()
     {
         $size   = $this->getSize();
         $width  = $size->getWidth();
@@ -303,7 +303,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    final public function strip()
+    public function strip()
     {
         // GD strips profiles and comment, so there's nothing to do here
         return $this;

--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -24,7 +24,7 @@ use Imagine\Exception\RuntimeException;
 /**
  * Imagine implementation using the GD library
  */
-final class Imagine extends AbstractImagine
+class Imagine extends AbstractImagine
 {
     /**
      * @var array

--- a/lib/Imagine/Gmagick/Drawer.php
+++ b/lib/Imagine/Gmagick/Drawer.php
@@ -24,7 +24,7 @@ use Imagine\Image\PointInterface;
 /**
  * Drawer implementation using the Gmagick PHP extension
  */
-final class Drawer implements DrawerInterface
+class Drawer implements DrawerInterface
 {
     /**
      * @var \Gmagick

--- a/lib/Imagine/Gmagick/Font.php
+++ b/lib/Imagine/Gmagick/Font.php
@@ -18,7 +18,7 @@ use Imagine\Image\Palette\Color\ColorInterface;
 /**
  * Font implementation using the Gmagick PHP extension
  */
-final class Font extends AbstractFont
+class Font extends AbstractFont
 {
     /**
      * @var \Gmagick

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -29,7 +29,7 @@ use Imagine\Image\ProfileInterface;
 /**
  * Image implementation using the Gmagick PHP extension
  */
-final class Image extends AbstractImage
+class Image extends AbstractImage
 {
     /**
      * @var \Gmagick

--- a/lib/Imagine/Image/AbstractFont.php
+++ b/lib/Imagine/Image/AbstractFont.php
@@ -52,7 +52,7 @@ abstract class AbstractFont implements FontInterface
     /**
      * {@inheritdoc}
      */
-    final public function getFile()
+    public function getFile()
     {
         return $this->file;
     }
@@ -60,7 +60,7 @@ abstract class AbstractFont implements FontInterface
     /**
      * {@inheritdoc}
      */
-    final public function getSize()
+    public function getSize()
     {
         return $this->size;
     }
@@ -68,7 +68,7 @@ abstract class AbstractFont implements FontInterface
     /**
      * {@inheritdoc}
      */
-    final public function getColor()
+    public function getColor()
     {
         return $this->color;
     }

--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -16,7 +16,7 @@ use Imagine\Exception\InvalidArgumentException;
 /**
  * A box implementation
  */
-final class Box implements BoxInterface
+class Box implements BoxInterface
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Fill/Gradient/Horizontal.php
+++ b/lib/Imagine/Image/Fill/Gradient/Horizontal.php
@@ -16,7 +16,7 @@ use Imagine\Image\PointInterface;
 /**
  * Horizontal gradient fill
  */
-final class Horizontal extends Linear
+class Horizontal extends Linear
 {
     /**
      * {@inheritdoc}

--- a/lib/Imagine/Image/Fill/Gradient/Linear.php
+++ b/lib/Imagine/Image/Fill/Gradient/Linear.php
@@ -43,7 +43,7 @@ abstract class Linear implements FillInterface
      * @param ColorInterface $start
      * @param ColorInterface $end
      */
-    final public function __construct($length, ColorInterface $start, ColorInterface $end)
+    public function __construct($length, ColorInterface $start, ColorInterface $end)
     {
         $this->length = $length;
         $this->start  = $start;
@@ -53,7 +53,7 @@ abstract class Linear implements FillInterface
     /**
      * {@inheritdoc}
      */
-    final public function getColor(PointInterface $position)
+    public function getColor(PointInterface $position)
     {
         $l = $this->getDistance($position);
 
@@ -71,7 +71,7 @@ abstract class Linear implements FillInterface
     /**
      * @return ColorInterface
      */
-    final public function getStart()
+    public function getStart()
     {
         return $this->start;
     }
@@ -79,7 +79,7 @@ abstract class Linear implements FillInterface
     /**
      * @return ColorInterface
      */
-    final public function getEnd()
+    public function getEnd()
     {
         return $this->end;
     }

--- a/lib/Imagine/Image/Fill/Gradient/Vertical.php
+++ b/lib/Imagine/Image/Fill/Gradient/Vertical.php
@@ -16,7 +16,7 @@ use Imagine\Image\PointInterface;
 /**
  * Vertical gradient fill
  */
-final class Vertical extends Linear
+class Vertical extends Linear
 {
     /**
      * {@inheritdoc}

--- a/lib/Imagine/Image/Histogram/Bucket.php
+++ b/lib/Imagine/Image/Histogram/Bucket.php
@@ -14,7 +14,7 @@ namespace Imagine\Image\Histogram;
 /**
  * Bucket histogram
  */
-final class Bucket implements \Countable
+class Bucket implements \Countable
 {
     /**
      * @var Range

--- a/lib/Imagine/Image/Histogram/Range.php
+++ b/lib/Imagine/Image/Histogram/Range.php
@@ -16,7 +16,7 @@ use Imagine\Exception\OutOfBoundsException;
 /**
  * Range histogram
  */
-final class Range
+class Range
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Palette/Color/CMYK.php
+++ b/lib/Imagine/Image/Palette/Color/CMYK.php
@@ -15,7 +15,7 @@ use Imagine\Image\Palette\CMYK as CMYKPalette;
 use Imagine\Exception\RuntimeException;
 use Imagine\Exception\InvalidArgumentException;
 
-final class CMYK implements ColorInterface
+class CMYK implements ColorInterface
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Palette/Color/Gray.php
+++ b/lib/Imagine/Image/Palette/Color/Gray.php
@@ -14,7 +14,7 @@ namespace Imagine\Image\Palette\Color;
 use Imagine\Image\Palette\Grayscale;
 use Imagine\Exception\InvalidArgumentException;
 
-final class Gray implements ColorInterface
+class Gray implements ColorInterface
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Palette/Color/RGB.php
+++ b/lib/Imagine/Image/Palette/Color/RGB.php
@@ -14,7 +14,7 @@ namespace Imagine\Image\Palette\Color;
 use Imagine\Image\Palette\RGB as RGBPalette;
 use Imagine\Exception\InvalidArgumentException;
 
-final class RGB implements ColorInterface
+class RGB implements ColorInterface
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Point.php
+++ b/lib/Imagine/Image/Point.php
@@ -16,7 +16,7 @@ use Imagine\Exception\InvalidArgumentException;
 /**
  * The point class
  */
-final class Point implements PointInterface
+class Point implements PointInterface
 {
     /**
      * @var integer

--- a/lib/Imagine/Image/Point/Center.php
+++ b/lib/Imagine/Image/Point/Center.php
@@ -18,7 +18,7 @@ use Imagine\Image\PointInterface;
 /**
  * Point center
  */
-final class Center implements PointInterface
+class Center implements PointInterface
 {
     /**
      * @var BoxInterface

--- a/lib/Imagine/Imagick/Drawer.php
+++ b/lib/Imagine/Imagick/Drawer.php
@@ -23,7 +23,7 @@ use Imagine\Image\PointInterface;
 /**
  * Drawer implementation using the Imagick PHP extension
  */
-final class Drawer implements DrawerInterface
+class Drawer implements DrawerInterface
 {
     /**
      * @var Imagick

--- a/lib/Imagine/Imagick/Font.php
+++ b/lib/Imagine/Imagick/Font.php
@@ -18,7 +18,7 @@ use Imagine\Image\Palette\Color\ColorInterface;
 /**
  * Font implementation using the Imagick PHP extension
  */
-final class Font extends AbstractFont
+class Font extends AbstractFont
 {
     /**
      * @var \Imagick

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -31,7 +31,7 @@ use Imagine\Image\Palette\PaletteInterface;
 /**
  * Image implementation using the Imagick PHP extension
  */
-final class Image extends AbstractImage
+class Image extends AbstractImage
 {
     /**
      * @var \Imagick

--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -25,7 +25,7 @@ use Imagine\Image\Palette\Grayscale;
 /**
  * Imagine implementation using the Imagick PHP extension
  */
-final class Imagine extends AbstractImagine
+class Imagine extends AbstractImagine
 {
     /**
      * @throws RuntimeException


### PR DESCRIPTION
This solves #162.

After thinking about it, I think we should open the interface so Imagine would be more hackable. I don't think classes should be extended, anyway, if some use case require it, let's give developers the ability to do so.

I propose to do it now as it would solve an issue toward version 1.0
