### PR TITLE
Update Image.php

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -181,14 +181,16 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      */
-    public function paste(ImageInterface $image, PointInterface $start)
+    public function paste(ImageInterface $image, PointInterface $start, $canPasteOutOfBound = false)
     {
         if (!$image instanceof self) {
             throw new InvalidArgumentException(sprintf('Imagick\Image can only paste() Imagick\Image instances, %s given', get_class($image)));
         }
 
-        if (!$this->getSize()->contains($image->getSize(), $start)) {
-            throw new OutOfBoundsException('Cannot paste image of the given size at the specified position, as it moves outside of the current image\'s box');
+        if ($canPasteOutOfBound === false) {
+            if (!$this->getSize()->contains($image->getSize(), $start)) {
+                throw new OutOfBoundsException('Cannot paste image of the given size at the specified position, as it moves outside of the current image\'s box');
+            }
         }
 
         try {


### PR DESCRIPTION
I have a legit/production use case where a user can upload an image, resize, rotate and position (by panning) it in a predefined editor area. If I use native ImageMagic functions, I can successfully render the image even if the user places the image right near the border of editor area (this will generate an image with the size of my edit area, mostly black or transparent [depending on save format] as there is no image there, and on a side, user's uploaded image).

My app (and future potential apps) will need this functionality, where you can paste things even if it is out of bounds. With Imagine, it is not possible as it throws "OutOfBoundsException" exception in "paste" function.

Solution was to add a 3rd preference parameter so the developer can decide if it is okay to paste out of bound. Default case is to throw the exception. I think this is a useful feature.

Please note that I only changed on "/Imagick/Image.php". Potentially I can help with porting this change to other library specific files. Thanks.
