### PR TITLE
Add THUMBNAIL_UPSCALE setting

### DIFF
--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -213,9 +213,9 @@ final class Transformation implements FilterInterface, ManipulatorInterface
     /**
      * {@inheritdoc}
      */
-    public function thumbnail(BoxInterface $size, $mode = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
+    public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
-        return $this->add(new Thumbnail($size, $mode, $filter));
+        return $this->add(new Thumbnail($size, $settings, $filter));
     }
 
     /**

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -30,7 +30,7 @@ abstract class AbstractImage implements ImageInterface
     {
         $allSettings = ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE;
 
-        if ($settings & ~$allSettings) {
+        if (!is_int($settings) || ($settings & ~$allSettings)) {
             throw new InvalidArgumentException('Invalid setting specified');
         }
 

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -41,6 +41,8 @@ abstract class AbstractImage implements ImageInterface
             throw new InvalidArgumentException('Invalid mode specified');
         }
 
+        $allowUpscale = (bool) ($settings & ImageInterface::THUMBNAIL_UPSCALE);
+
         $imageSize = $this->getSize();
         $ratios = array(
             $size->getWidth() / $imageSize->getWidth(),
@@ -53,7 +55,7 @@ abstract class AbstractImage implements ImageInterface
         $thumbnail->strip();
         // if target width is larger than image width
         // AND target height is longer than image height
-        if ($size->contains($imageSize)) {
+        if ($size->contains($imageSize) && !$allowUpscale) {
             return $thumbnail;
         }
 
@@ -68,6 +70,10 @@ abstract class AbstractImage implements ImageInterface
             $thumbnail->resize($imageSize, $filter);
         } else {
             if (!$imageSize->contains($size)) {
+                if ($allowUpscale) {
+                    $imageSize = $imageSize->scale($ratio);
+                    $thumbnail->resize($imageSize, $filter);
+                }
                 $size = new Box(
                     min($imageSize->getWidth(), $size->getWidth()),
                     min($imageSize->getHeight(), $size->getHeight())

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -55,7 +55,10 @@ abstract class AbstractImage implements ImageInterface
             $ratio = max($ratios);
         }
 
-        if ($mode === ImageInterface::THUMBNAIL_OUTBOUND) {
+        if ($mode === ImageInterface::THUMBNAIL_INSET) {
+            $imageSize = $imageSize->scale($ratio);
+            $thumbnail->resize($imageSize, $filter);
+        } else {
             if (!$imageSize->contains($size)) {
                 $size = new Box(
                     min($imageSize->getWidth(), $size->getWidth()),
@@ -69,9 +72,6 @@ abstract class AbstractImage implements ImageInterface
                 max(0, round(($imageSize->getWidth() - $size->getWidth()) / 2)),
                 max(0, round(($imageSize->getHeight() - $size->getHeight()) / 2))
             ), $size);
-        } else {
-            $imageSize = $imageSize->scale($ratio);
-            $thumbnail->resize($imageSize, $filter);
         }
 
         return $thumbnail;

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -26,8 +26,16 @@ abstract class AbstractImage implements ImageInterface
      *
      * @return ImageInterface
      */
-    public function thumbnail(BoxInterface $size, $mode = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
+    public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
+        $allSettings = ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE;
+
+        if ($settings & ~$allSettings) {
+            throw new InvalidArgumentException('Invalid setting specified');
+        }
+
+        $mode = $settings & (ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
+
         if ($mode !== ImageInterface::THUMBNAIL_INSET &&
             $mode !== ImageInterface::THUMBNAIL_OUTBOUND) {
             throw new InvalidArgumentException('Invalid mode specified');

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -62,7 +62,7 @@ abstract class AbstractImage implements ImageInterface
                     min($imageSize->getHeight(), $size->getHeight())
                 );
             } else {
-                $imageSize = $thumbnail->getSize()->scale($ratio);
+                $imageSize = $imageSize->scale($ratio);
                 $thumbnail->resize($imageSize, $filter);
             }
             $thumbnail->crop(new Point(
@@ -70,13 +70,8 @@ abstract class AbstractImage implements ImageInterface
                 max(0, round(($imageSize->getHeight() - $size->getHeight()) / 2))
             ), $size);
         } else {
-            if (!$imageSize->contains($size)) {
-                $imageSize = $imageSize->scale($ratio);
-                $thumbnail->resize($imageSize, $filter);
-            } else {
-                $imageSize = $thumbnail->getSize()->scale($ratio);
-                $thumbnail->resize($imageSize, $filter);
-            }
+            $imageSize = $imageSize->scale($ratio);
+            $thumbnail->resize($imageSize, $filter);
         }
 
         return $thumbnail;

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -28,23 +28,7 @@ abstract class AbstractImage implements ImageInterface
      */
     public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
-        // Preserve BC until version 1.0
-        if ($settings === 'inset') {
-            $settings = ImageInterface::THUMBNAIL_INSET;
-        } elseif ($settings === 'outbound') {
-            $settings = ImageInterface::THUMBNAIL_OUTBOUND;
-        }
-
-        $allSettings = ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE;
-
-        if (!is_int($settings) || ($settings & ~$allSettings)) {
-            throw new InvalidArgumentException('Invalid setting specified');
-        }
-
-        if ($settings & ImageInterface::THUMBNAIL_INSET &&
-            $settings & ImageInterface::THUMBNAIL_OUTBOUND) {
-            throw new InvalidArgumentException('Only one mode should be specified');
-        }
+        $settings = $this->checkThumbnailSettings($settings);
 
         $mode = $settings & (ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
 
@@ -100,6 +84,32 @@ abstract class AbstractImage implements ImageInterface
         }
 
         return $thumbnail;
+    }
+
+    /**
+     * Check the settings argument in thumbnail() method
+     */
+    private function checkThumbnailSettings($settings)
+    {
+        // Preserve BC until version 1.0
+        if ($settings === 'inset') {
+            $settings = ImageInterface::THUMBNAIL_INSET;
+        } elseif ($settings === 'outbound') {
+            $settings = ImageInterface::THUMBNAIL_OUTBOUND;
+        }
+
+        $allSettings = ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE;
+
+        if (!is_int($settings) || ($settings & ~$allSettings)) {
+            throw new InvalidArgumentException('Invalid setting specified');
+        }
+
+        if ($settings & ImageInterface::THUMBNAIL_INSET &&
+            $settings & ImageInterface::THUMBNAIL_OUTBOUND) {
+            throw new InvalidArgumentException('Only one mode should be specified');
+        }
+
+        return $settings;
     }
 
     /**

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -28,6 +28,13 @@ abstract class AbstractImage implements ImageInterface
      */
     public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
+        // Preserve BC until version 1.0
+        if ($settings === 'inset') {
+            $settings = ImageInterface::THUMBNAIL_INSET;
+        } elseif ($settings === 'outbound') {
+            $settings = ImageInterface::THUMBNAIL_OUTBOUND;
+        }
+
         $allSettings = ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE;
 
         if (!is_int($settings) || ($settings & ~$allSettings)) {

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -36,6 +36,10 @@ abstract class AbstractImage implements ImageInterface
 
         $mode = $settings & (ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
 
+        if (!$mode) {
+            $mode = ImageInterface::THUMBNAIL_INSET;
+        }
+
         if ($mode !== ImageInterface::THUMBNAIL_INSET &&
             $mode !== ImageInterface::THUMBNAIL_OUTBOUND) {
             throw new InvalidArgumentException('Invalid mode specified');

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -41,15 +41,15 @@ abstract class AbstractImage implements ImageInterface
             throw new InvalidArgumentException('Invalid setting specified');
         }
 
+        if ($settings & ImageInterface::THUMBNAIL_INSET &&
+            $settings & ImageInterface::THUMBNAIL_OUTBOUND) {
+            throw new InvalidArgumentException('Only one mode should be specified');
+        }
+
         $mode = $settings & (ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
 
         if (!$mode) {
             $mode = ImageInterface::THUMBNAIL_INSET;
-        }
-
-        if ($mode !== ImageInterface::THUMBNAIL_INSET &&
-            $mode !== ImageInterface::THUMBNAIL_OUTBOUND) {
-            throw new InvalidArgumentException('Invalid mode specified');
         }
 
         $allowUpscale = (bool) ($settings & ImageInterface::THUMBNAIL_UPSCALE);

--- a/lib/Imagine/Image/ManipulatorInterface.php
+++ b/lib/Imagine/Image/ManipulatorInterface.php
@@ -21,8 +21,9 @@ use Imagine\Image\Fill\FillInterface;
  */
 interface ManipulatorInterface
 {
-    const THUMBNAIL_INSET    = 'inset';
-    const THUMBNAIL_OUTBOUND = 'outbound';
+    const THUMBNAIL_INSET    = 1;
+    const THUMBNAIL_OUTBOUND = 2;
+    const THUMBNAIL_UPSCALE  = 4;
 
     /**
      * Copies current source image into a new ImageInterface instance
@@ -149,14 +150,14 @@ interface ManipulatorInterface
      * Returns it as a new image, doesn't modify the current image
      *
      * @param BoxInterface $size
-     * @param string       $mode
+     * @param integer      $settings
      * @param string       $filter The filter to use for resizing, one of ImageInterface::FILTER_*
      *
      * @throws RuntimeException
      *
      * @return ManipulatorInterface
      */
-    public function thumbnail(BoxInterface $size, $mode = self::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED);
+    public function thumbnail(BoxInterface $size, $settings = self::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED);
 
     /**
      * Applies a given mask to current image's alpha channel

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -266,11 +266,11 @@ abstract class AbstractImageTest extends ImagineTestCase
         $this->assertNotSame($image, $thumbnail);
     }
 
-    public function testThumbnailWithInvalidModeShouldThrowAnException()
+    public function testThumbnailWithInvalidSettingShouldThrowAnException()
     {
         $factory = $this->getImagine();
         $image = $factory->open('tests/Imagine/Fixtures/google.png');
-        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Invalid mode specified');
+        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Invalid setting specified');
         $image->thumbnail(new Box(20, 20), "boumboum");
     }
 

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -310,6 +310,10 @@ abstract class AbstractImageTest extends ImagineTestCase
     public function provideDimensionsAndModesForThumbnailGeneration()
     {
         return array(
+            // support previous values of mode constants
+            array(320, 240, 32, 48, 'inset', 32, round(32 * 240 / 320)),
+            array(320, 240, 32, 48, 'outbound', 32, 48),
+
             // landscape with smaller portrait
             array(320, 240, 32, 48, ImageInterface::THUMBNAIL_INSET, 32, round(32 * 240 / 320)),
             array(320, 240, 32, 48, ImageInterface::THUMBNAIL_OUTBOUND, 32, 48),

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -274,6 +274,14 @@ abstract class AbstractImageTest extends ImagineTestCase
         $image->thumbnail(new Box(20, 20), "boumboum");
     }
 
+    public function testThumbnailWithInvalidModeShouldThrowAnException()
+    {
+        $factory = $this->getImagine();
+        $image = $factory->open('tests/Imagine/Fixtures/google.png');
+        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Invalid mode specified');
+        $image->thumbnail(new Box(20, 20), ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
+    }
+
     public function testResizeShouldReturnTheImage()
     {
         $factory = $this->getImagine();

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -330,6 +330,20 @@ abstract class AbstractImageTest extends ImagineTestCase
             array(24, 32, 240, 400, ImageInterface::THUMBNAIL_INSET, 24, 32),
             array(24, 32, 240, 400, ImageInterface::THUMBNAIL_OUTBOUND, 24, 32),
 
+            // landscape with larger portrait (allow upscale)
+            array(32, 24, 320, 300, ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_UPSCALE, 320, round(24 * 320 / 32)),
+            array(32, 24, 320, 300, ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE, 320, 300),
+            // landscape with larger landscape (allow upscale)
+            array(32, 24, 320, 200, ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_UPSCALE, round(32 * 200 / 24), 200),
+            array(32, 24, 320, 200, ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE, 320, 200),
+
+            // portrait with larger portrait (allow upscale)
+            array(24, 32, 240, 300, ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_UPSCALE, round(24 * 300 / 32), 300),
+            array(24, 32, 240, 300, ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE, 240, 300),
+            // portrait with larger landscape (allow upscale)
+            array(24, 32, 240, 400, ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_UPSCALE, 240, round(32 * 240 / 24)),
+            array(24, 32, 240, 400, ImageInterface::THUMBNAIL_OUTBOUND | ImageInterface::THUMBNAIL_UPSCALE, 240, 400),
+
             // landscape with intersect portrait
             array(320, 240, 340, 220, ImageInterface::THUMBNAIL_INSET, round(220 * 320 / 240), 220),
             array(320, 240, 340, 220, ImageInterface::THUMBNAIL_OUTBOUND, 320, 220),

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -278,7 +278,7 @@ abstract class AbstractImageTest extends ImagineTestCase
     {
         $factory = $this->getImagine();
         $image = $factory->open('tests/Imagine/Fixtures/google.png');
-        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Invalid mode specified');
+        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Only one mode should be specified');
         $image->thumbnail(new Box(20, 20), ImageInterface::THUMBNAIL_INSET | ImageInterface::THUMBNAIL_OUTBOUND);
     }
 

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -291,9 +291,9 @@ abstract class AbstractImageTest extends ImagineTestCase
     {
         $factory = $this->getImagine();
         $image   = $factory->create(new Box($sourceW, $sourceH));
-        $inset   = $image->thumbnail(new Box($thumbW, $thumbH), $mode);
+        $thumb   = $image->thumbnail(new Box($thumbW, $thumbH), $mode);
 
-        $size = $inset->getSize();
+        $size = $thumb->getSize();
 
         $this->assertEquals($expectedW, $size->getWidth());
         $this->assertEquals($expectedH, $size->getHeight());
@@ -309,10 +309,10 @@ abstract class AbstractImageTest extends ImagineTestCase
             array(320, 240, 32, 16, ImageInterface::THUMBNAIL_INSET, round(16 * 320 / 240), 16),
             array(320, 240, 32, 16, ImageInterface::THUMBNAIL_OUTBOUND, 32, 16),
 
-            // portait with smaller portrait
+            // portrait with smaller portrait
             array(240, 320, 24, 48, ImageInterface::THUMBNAIL_INSET, 24, round(24 * 320 / 240)),
             array(240, 320, 24, 48, ImageInterface::THUMBNAIL_OUTBOUND, 24, 48),
-            // portait with smaller landscape
+            // portrait with smaller landscape
             array(240, 320, 24, 16, ImageInterface::THUMBNAIL_INSET, round(16 * 240 / 320), 16),
             array(240, 320, 24, 16, ImageInterface::THUMBNAIL_OUTBOUND, 24, 16),
 
@@ -323,10 +323,10 @@ abstract class AbstractImageTest extends ImagineTestCase
             array(32, 24, 320, 200, ImageInterface::THUMBNAIL_INSET, 32, 24),
             array(32, 24, 320, 200, ImageInterface::THUMBNAIL_OUTBOUND, 32, 24),
 
-            // portait with larger portrait
+            // portrait with larger portrait
             array(24, 32, 240, 300, ImageInterface::THUMBNAIL_INSET, 24, 32),
             array(24, 32, 240, 300, ImageInterface::THUMBNAIL_OUTBOUND, 24, 32),
-            // portait with larger landscape
+            // portrait with larger landscape
             array(24, 32, 240, 400, ImageInterface::THUMBNAIL_INSET, 24, 32),
             array(24, 32, 240, 400, ImageInterface::THUMBNAIL_OUTBOUND, 24, 32),
 
@@ -339,7 +339,7 @@ abstract class AbstractImageTest extends ImagineTestCase
         );
     }
 
-    public function testThumbnailGenerationToDimensionsLergestThanSource()
+    public function testThumbnailGenerationToDimensionsLargestThanSource()
     {
         $test_image = 'tests/Imagine/Fixtures/google.png';
         $test_image_width = 364;


### PR DESCRIPTION
This setting allows upscaling the source image if needed,
so that the result matches the requested size instead of being smaller.
