### PR TITLE
Fix gmagick memory leak

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -73,6 +73,8 @@ final class Image extends AbstractImage
         if ($this->gmagick instanceof \Gmagick) {
             $this->gmagick->clear();
             $this->gmagick->destroy();
+            unset($this->layers);
+            unset($this->gmagick);
         }
     }
 

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -79,6 +79,7 @@ final class Image extends AbstractImage
      *
      * These lines inside destructor cause segmentation fault
      * @see https://github.com/avalanche123/Imagine/issues/347
+     * @see https://bugs.php.net/bug.php?id=63677
      *
      * So if you need, you can clear resources manually by calling this method
      */

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -66,16 +66,26 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Destroys allocated gmagick resources
+     * Destroys gmagick instance
      */
     public function __destruct()
     {
-        if ($this->gmagick instanceof \Gmagick) {
-            $this->gmagick->clear();
-            $this->gmagick->destroy();
-            $this->layers = null;
-            $this->gmagick = null;
-        }
+        $this->gmagick = null;
+        $this->layers = null; // layers contains gmagick instance
+    }
+
+    /**
+     * Destroys allocated gmagick resources
+     *
+     * These lines inside destructor cause segmentation fault
+     * @see https://github.com/avalanche123/Imagine/issues/347
+     *
+     * So if you need, you can clear resources manually by calling this method
+     */
+    public function destroyGmagick()
+    {
+        $this->gmagick->clear();
+        $this->gmagick->destroy();
     }
 
     /**

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -73,8 +73,8 @@ final class Image extends AbstractImage
         if ($this->gmagick instanceof \Gmagick) {
             $this->gmagick->clear();
             $this->gmagick->destroy();
-            unset($this->layers);
-            unset($this->gmagick);
+            $this->layers = null;
+            $this->gmagick = null;
         }
     }
 

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -22,10 +22,6 @@ class ImageTest extends AbstractImageTest
     {
         parent::setUp();
 
-        // disable GC while https://bugs.php.net/bug.php?id=63677 is still open
-        // If GC enabled, Gmagick unit tests fail
-        gc_disable();
-
         if (!class_exists('Gmagick')) {
             $this->markTestSkipped('Gmagick is not installed');
         }


### PR DESCRIPTION
We need to unset gmagick instance to free memory. And unset layers instance because it contains reference to gmagick too.