### PR TITLE
Update ImageMagick download link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - sudo apt-get install -y libtiff-dev libjpeg-dev libdjvulibre-dev libwmf-dev pkg-config
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - sh -c " if [ '$IMAGINE_DRIVER' = 'imagick' ]; then
-              wget http://www.imagemagick.org/download/legacy/ImageMagick-6.8.5-10.tar.gz;
+              wget http://www.imagemagick.org/download/releases/ImageMagick-6.8.5-10.tar.gz;
               tar xzf ImageMagick-6.8.5-10.tar.gz;
               cd ImageMagick-6.8.5-10;
               ./configure --prefix=/opt/imagemagick;


### PR DESCRIPTION
http://www.imagemagick.org/download/legacy/ImageMagick-6.8.5-10.tar.gz is now a dead link
