### PR TITLE
Add given coordinates to Point exception to ease debugging.

### DIFF
--- a/lib/Imagine/Image/Point.php
+++ b/lib/Imagine/Image/Point.php
@@ -39,7 +39,7 @@ final class Point implements PointInterface
     public function __construct($x, $y)
     {
         if ($x < 0 || $y < 0) {
-            throw new InvalidArgumentException('A coordinate cannot be positioned outside of a bounding box');
+            throw new InvalidArgumentException(sprintf('A coordinate cannot be positioned outside of a bounding box (x: %s, y: %s given)', $x, $y));
         }
 
         $this->x = $x;


### PR DESCRIPTION
I've had a bug in my application where due to a rounding error I ended up with a slightly negative coordinate instead of 0. Through my logs I was able to see that the Point class was where the Exception originated, but having the actual buggy coordinates in the logs as well would have made this type of error more obvious.

The library is reporting similar level of detail here: https://github.com/avalanche123/Imagine/blob/develop/lib/Imagine/Image/Box.php#L42
