### PR TITLE
Imagick: Don't break stripping if standard profile cannot be set

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -170,6 +170,11 @@ final class Image extends AbstractImage
     {
         try {
             $this->profile($this->palette->profile());
+        } catch (RuntimeException $e) {
+            trigger_error($e->getMessage(), E_USER_NOTICE);
+        }
+
+        try {
             $this->imagick->stripImage();
         } catch (\ImagickException $e) {
             throw new RuntimeException('Strip operation failed', $e->getCode(), $e);


### PR DESCRIPTION
As described in https://github.com/avalanche123/Imagine/issues/353 imagick extension throws an exception if the standard profile cannot be set to image before stripping it. 

Now, it is just triggering a warning but doesn't break the stripping anymore. 

In my opinion this makes more sense since stripping can be done without having the standard profile set.
