### PR TITLE
Fix array_merge in AbstractMetadataReader when file is not local

### DIFF
--- a/lib/Imagine/Image/Metadata/AbstractMetadataReader.php
+++ b/lib/Imagine/Image/Metadata/AbstractMetadataReader.php
@@ -28,7 +28,7 @@ abstract class AbstractMetadataReader implements MetadataReaderInterface
             return new MetadataBag(array_merge(array('filepath' => realpath($file), 'uri' => $file), $this->extractFromFile($file)));
         }
 
-        return new MetadataBag(array_merge(array('uri' => $file)), $this->extractFromFile($file));
+        return new MetadataBag(array_merge(array('uri' => $file), $this->extractFromFile($file)));
     }
 
     /**


### PR DESCRIPTION
The parentheses were wrong in array_merge for this case, leaving out the metadata
for non local files.
