### PR TITLE
Change the ImageMagick download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - sudo apt-get install -y libtiff-dev libjpeg-dev libdjvulibre-dev libwmf-dev pkg-config
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - sh -e -c " if [ '$IMAGINE_DRIVER' = 'imagick' ]; then
-              wget http://www.imagemagick.org/download/ImageMagick-6.8.9-10.tar.gz;
+              wget http://www.imagemagick.org/download/releases/ImageMagick-6.8.9-10.tar.gz;
               tar xzf ImageMagick-6.8.9-10.tar.gz;
               cd ImageMagick-6.8.9-10;
               ./configure --prefix=/opt/imagemagick;


### PR DESCRIPTION
The ``download/`` folder only contains the archive for the latest release, and so the URL becomes invalid each time a new release is done. Using permanent URLs for the download is better