### PR TITLE
Changed call_user_func_array into regular method call

### DIFF
--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -96,7 +96,7 @@ final class Transformation implements FilterInterface, ManipulatorInterface
     {
         if (null === $this->sorted) {
             ksort($this->filters);
-            $this->sorted = call_user_func_array('array_merge', $this->filters);
+            $this->sorted = array_merge($this->filters);
         }
 
         return $this->sorted;


### PR DESCRIPTION
Hi,
when you create a transformation and don't add filters, yet still use apply, then you get a E_WARNINGS from the Transformation::apply

WARN (4): E_WARNING: array_merge() expects at least 1 parameter, 0 given in Transformation.php line 99
WARN (4): E_WARNING: array_reduce() expects parameter 1 to be array, null given in Transformation.php line 114 

The call_user_func_array does not work with an empty array like $this->filters is by default in Transformation.
And since the call is always just array_merge with argument $this->filters being a single array there is no need AFAIS to use call_user_func_array. And it also gives a WARNING and stops working when you trigger at PHP warnings.

For example
```
            $transformation
                ->apply($imagine->open($imageRealPath))
                ->thumbnail($size, $mode)
                ->save($imageThumbRealPath(), array('jpeg_quality' => $jpeg_quality, 'png_compression_level' => $png_compression_level));
```