### PR TITLE
Fix signature mismatch in IsImageEqual constraint

### DIFF
--- a/lib/Imagine/Test/Constraint/IsImageEqual.php
+++ b/lib/Imagine/Test/Constraint/IsImageEqual.php
@@ -61,7 +61,7 @@ class IsImageEqual extends \PHPUnit_Framework_Constraint
     /**
      * {@inheritdoc}
      */
-    public function evaluate($other)
+    public function evaluate($other, $description = '', $returnResult = false)
     {
         if (!$other instanceof ImageInterface) {
             throw \PHPUnit_Util_InvalidArgumentHelper::factory(1, 'Imagine\Image\ImageInterface');


### PR DESCRIPTION
The signature of \Imagine\Test\Constraint\IsImageEqual::evaluate does not match the one in the parent class \PHPUnit_Framework_Constraint. In PHP5.5 this leads to a runtime notice.
This change fixes the signature.