### PR TITLE
Fix for extracting EXIF metadata from stream

### DIFF
--- a/lib/Imagine/Image/Metadata/ExifMetadataReader.php
+++ b/lib/Imagine/Image/Metadata/ExifMetadataReader.php
@@ -51,6 +51,7 @@ class ExifMetadataReader extends AbstractMetadataReader
      */
     protected function extractFromStream($resource)
     {
+        rewind($resource);
         return $this->doReadData(stream_get_contents($resource));
     }
 


### PR DESCRIPTION
The stream's contents have probably already been read, thus the pointer is at the EOF already.
Rewinding the stream fixes this issue.