### PR TITLE
composer.archive.exclude: .git (and dot files from root), /tests …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,17 @@
         "branch-alias": {
             "dev-develop": "0.7-dev"
         }
+    },
+    "archive": {
+        "exclude": [
+            "/.*",
+            "/tests",
+            "/vendor",
+            "/bin",
+            "docs/_build",
+            "Imagine-*.tgz",
+            "imagine-*.phar",
+            "composer.phar"
+        ]
     }
 }


### PR DESCRIPTION
composer.archive.exclude: .git (and dot files from root), /tests and stuff from .gitignore

Half the size of this repo is just .git and /tests folders. With time .git gets only bigger.
I think it is good to exclude unnecessary files from archive (less is better).