### PR TITLE
Enhancement: Use SVG badge for Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Imagine
 [![project status](http://stillmaintained.com/avalanche123/Imagine.png)](http://stillmaintained.com/avalanche123/Imagine)
-[![Build Status](https://secure.travis-ci.org/avalanche123/Imagine.png?branch=develop)](http://travis-ci.org/avalanche123/Imagine)
+[![Build Status](https://travis-ci.org/avalanche123/Imagine.svg?branch=develop)](https://travis-ci.org/avalanche123/Imagine)
 
 Tweet about it using the [#php_imagine](https://twitter.com/search?q=%23php_imagine) hashtag.
 


### PR DESCRIPTION
This PR

* [x] uses an SVG badge for displaying the Travis build status, as it pleases the eye

### Before

<img width="939" alt="screen shot 2015-07-09 at 22 21 49" src="https://cloud.githubusercontent.com/assets/605483/8611047/01cc5ff0-2689-11e5-8cc1-50a903571f38.png">

### After

<img width="804" alt="screen shot 2015-07-09 at 22 22 13" src="https://cloud.githubusercontent.com/assets/605483/8611048/06091ff4-2689-11e5-8505-e2880cfc187e.png">

