### PR TITLE
Fix: Add composer.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tests/Imagine/Fixtures/results/in_out
 docs/_build
 Imagine-*.tgz
 imagine-*.phar
+composer.lock
 composer.phar
 vendor/
 bin/


### PR DESCRIPTION
This PR

* [x] adds `composer.lock` to `.gitignore`

:bulb: It shows up as untracked file when I install dependencies.