### PR TITLE
Fix: Download ImageMagick tar from appropriate location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script:
   - sudo apt-get install -y libtiff-dev libjpeg-dev libdjvulibre-dev libwmf-dev pkg-config
   - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - sh -e -c " if [ '$IMAGINE_DRIVER' = 'imagick' ]; then
-              wget http://www.imagemagick.org/download/releases/ImageMagick-6.8.9-10.tar.gz;
-              tar xzf ImageMagick-6.8.9-10.tar.gz;
+              wget http://www.imagemagick.org/download/releases/ImageMagick-6.8.9-10.tar.xz;
+              tar -xf ImageMagick-6.8.9-10.tar.xz;
               cd ImageMagick-6.8.9-10;
               ./configure --prefix=/opt/imagemagick;
               make -j;


### PR DESCRIPTION
This PR

* [x] uses the appropriate location from which to download the `ImageMagick-6.8.9-10` archive

:information_desk_person: Seems like the location has changed since the last PR (https://github.com/avalanche123/Imagine/pull/433) was merged.

See http://www.imagemagick.org/download/releases/.

/cc @romainneutron @stof