### PR TITLE
Fix open pdf with page parameter

### DIFF
--- a/lib/Imagine/Image/AbstractImagine.php
+++ b/lib/Imagine/Image/AbstractImagine.php
@@ -61,6 +61,13 @@ abstract class AbstractImagine implements ImagineInterface
             $path = (string) $path;
         }
 
+        $ext = pathinfo($path, PATHINFO_EXTENSION);
+
+        if(preg_match('/pdf\[[0-9]+\]/', $ext)){
+            $path = substr($path, 0, -strlen($ext));
+            $path = $path."pdf";
+        }
+
         $handle = @fopen($path, 'r');
 
         if (false === $handle) {

--- a/lib/Imagine/Image/AbstractImagine.php
+++ b/lib/Imagine/Image/AbstractImagine.php
@@ -57,9 +57,12 @@ abstract class AbstractImagine implements ImagineInterface
     protected function checkPath($path)
     {
         // provide compatibility with objects such as \SplFileInfo
+
         if (is_object($path) && method_exists($path, '__toString')) {
             $path = (string) $path;
         }
+
+        $originalPath = $path;
 
         $ext = pathinfo($path, PATHINFO_EXTENSION);
 
@@ -76,6 +79,6 @@ abstract class AbstractImagine implements ImagineInterface
 
         fclose($handle);
 
-        return $path;
+        return $originalPath;
     }
 }

--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -50,6 +50,14 @@ final class Imagine extends AbstractImagine
 
         try {
             $imagick = new \Imagick($path);
+
+            $ext = pathinfo($path, PATHINFO_EXTENSION);
+
+            if(preg_match('/pdf\[[0-9]+\]/', $ext)){
+                $path = substr($path, 0, -strlen($ext));
+                $path = $path."pdf";
+            }
+
             $image = new Image($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readFile($path));
         } catch (\Exception $e) {
             throw new RuntimeException(sprintf('Unable to open image %s', $path), $e->getCode(), $e);


### PR DESCRIPTION
Hi,

I'm currently using Imagine and I was confronted to a problem.

When I used Imagine to generate Images from PDF multi-pages files, Imagine generated me an image with another "image miniature" inside it. I wanted to generate a simple image and choose which page would be generate. When I was specifying a page (with .pdf[0]) like Imagick accept it, Imagine said to me that my file was not found (check path problem).

I asked a question on stack (I think it's more clear below) : 
http://stackoverflow.com/questions/31630229/imagine-imagick-cant-open-pdf-with-page-parameter

There is not many ressources or documentations about imagine working on PDF, so I made these modifications.

Hope this is not so dirty (my first contribution), but it seems work in my case.

Julien