### PR TITLE
Unsilence GD Library errors in Imagine\Gd\open()

### DIFF
--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -90,7 +90,7 @@ final class Imagine extends AbstractImagine
             throw new RuntimeException(sprintf('Failed to open file %s', $path));
         }
 
-        $resource = @imagecreatefromstring($data);
+        $resource = imagecreatefromstring($data);
 
         if (!is_resource($resource)) {
             throw new RuntimeException(sprintf('Unable to open image %s', $path));


### PR DESCRIPTION
I think silencing errors here is a bad idea because it obliterates potentially useful/vital information as to why the image could not be opened. With this error silenced a developer can only guess. In my case on a fresh PHP install I had forgotten to enable JPEG support. I spent several minutes looking for a remote URL issue (as in my case the image is opened from a remote URL) before I figured out the GD Library error was being silenced.

Is there a particular rationale for silencing these messages?
