### PR TITLE
Handle all possible orientations when autorotating

### DIFF
--- a/lib/Imagine/Filter/Basic/Autorotate.php
+++ b/lib/Imagine/Filter/Basic/Autorotate.php
@@ -43,16 +43,33 @@ class Autorotate implements FilterInterface
         $metadata = $image->metadata();
 
         switch (isset($metadata['ifd0.Orientation']) ? $metadata['ifd0.Orientation'] : null) {
-            case 3:
+            case 1: // top-left
+                break;
+            case 2: // top-right
+                $image->flipHorizontally();
+                break;
+            case 3: // bottom-right
                 $image->rotate(180, $this->getColor($image));
                 break;
-            case 6:
-                $image->rotate(90, $this->getColor($image));
+            case 4: // bottom-left
+                $image->flipHorizontally();
+                $image->rotate(180, $this->getColor($image));
                 break;
-            case 8:
+            case 5: // left-top
+                $image->flipHorizontally();
                 $image->rotate(-90, $this->getColor($image));
                 break;
-            default:
+            case 6: // right-top
+                $image->rotate(90, $this->getColor($image));
+                break;
+            case 7: // right-bottom
+                $image->flipHorizontally();
+                $image->rotate(90, $this->getColor($image));
+                break;
+            case 8: // left-bottom
+                $image->rotate(-90, $this->getColor($image));
+                break;
+            default: // Invalid orientation
                 break;
         }
 

--- a/tests/Imagine/Test/Filter/Basic/AutorotateTest.php
+++ b/tests/Imagine/Test/Filter/Basic/AutorotateTest.php
@@ -20,7 +20,7 @@ class AutorotateTest extends FilterTestCase
     /**
      * @dataProvider provideMetadataAndRotations
      */
-    public function testApply($expectedRotation, MetadataBag $metadata)
+    public function testApply($expectedRotation, $hFlipExpected, MetadataBag $metadata)
     {
         $image = $this->getImage();
         $image->expects($this->any())
@@ -36,6 +36,9 @@ class AutorotateTest extends FilterTestCase
                 ->with($expectedRotation);
         }
 
+        $image->expects($hFlipExpected ? $this->once() : $this->never())
+            ->method('flipHorizontally');
+
         $filter = new Autorotate($this->getColor());
         $filter->apply($image);
     }
@@ -43,14 +46,17 @@ class AutorotateTest extends FilterTestCase
     public function provideMetadataAndRotations()
     {
         return array(
-            array(null, new MetadataBag(array())),
-            array(null, new MetadataBag(array('ifd0.Orientation' => 0))),
-            array(null, new MetadataBag(array('ifd0.Orientation' => 1))),
-            array(null, new MetadataBag(array('ifd0.Orientation' => 2))),
-            array(null, new MetadataBag(array('ifd0.Orientation' => null))),
-            array(90, new MetadataBag(array('ifd0.Orientation' => 6))),
-            array(180, new MetadataBag(array('ifd0.Orientation' => 3))),
-            array(-90, new MetadataBag(array('ifd0.Orientation' => 8))),
+            array(null, false, new MetadataBag(array())),
+            array(null, false, new MetadataBag(array('ifd0.Orientation' => null))),
+            array(null, false, new MetadataBag(array('ifd0.Orientation' => 0))),
+            array(null, false, new MetadataBag(array('ifd0.Orientation' => 1))),
+            array(null, true, new MetadataBag(array('ifd0.Orientation' => 2))),
+            array(180, false, new MetadataBag(array('ifd0.Orientation' => 3))),
+            array(180, true, new MetadataBag(array('ifd0.Orientation' => 4))),
+            array(-90, true, new MetadataBag(array('ifd0.Orientation' => 5))),
+            array(90, false, new MetadataBag(array('ifd0.Orientation' => 6))),
+            array(90, true, new MetadataBag(array('ifd0.Orientation' => 7))),
+            array(-90, false, new MetadataBag(array('ifd0.Orientation' => 8))),
         );
     }
 }


### PR DESCRIPTION
EXIF allows for eight orientations, four of which are currently
handled.  This adds functionality to handle the remaining four, which
have to be mirrored as well as rotated.