### PR TITLE
Fixed \Imagine\Gmagick\Image::fill

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -501,8 +501,8 @@ final class Image extends AbstractImage
             $w = $size->getWidth();
             $h = $size->getHeight();
 
-            for ($x = 0; $x <= $w; $x++) {
-                for ($y = 0; $y <= $h; $y++) {
+            for ($x = 0; $x < $w; $x++) {
+                for ($y = 0; $y < $h; $y++) {
                     $pixel = $this->getColor($fill->getColor(new Point($x, $y)));
 
                     $draw->setfillcolor($pixel);


### PR DESCRIPTION
Function `\Imagine\Gmagick\Image::fill` browse some pixels outside of the image, due to a range error in `for` loop.

**Disclaimer:** Sorry, I didn't had time to write tests, I just wanted to point out this issue, and at least to propose a patch...
