### PR TITLE
Workaround an issue where gmagick segfaults.

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -71,8 +71,14 @@ final class Image extends AbstractImage
     public function __destruct()
     {
         if ($this->gmagick instanceof \Gmagick) {
-            $this->gmagick->clear();
-            $this->gmagick->destroy();
+            $instance = $this->gmagick->current();
+
+            if ($instance) {
+                $instance->clear();
+                $instance->destroy();
+                unset($instance);
+            }
+            unset($this->gmagick);
         }
     }
 


### PR DESCRIPTION
This approach works around an anoying segfault when gmagick instances are destroyed.

It might be that memory is messed a bit, but better then segfaults.
