### PR TITLE
Reverse deprecated version logic.

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -105,10 +105,10 @@ final class Image extends AbstractImage
     public function copy()
     {
         try {
-            if (version_compare(phpversion("imagick"), "3.1.0b1", ">=") || defined("HHVM_VERSION")) {
-                $clone = clone $this->imagick;
-            } else {
+            if (version_compare(phpversion("imagick"), "3.1.0b1", "<") && !defined("HHVM_VERSION")) {
                 $clone = $this->imagick->clone();
+            } else {
+                $clone = clone $this->imagick;
             }
         } catch (\ImagickException $e) {
             throw new RuntimeException('Copy operation failed', $e->getCode(), $e);


### PR DESCRIPTION
Imagick does not have a version contained inside it, unless it was packaged by PECL. For versions compiled from source, the version is not a semver number, and so can't be compared sanely. This change makes the code assume that Imagick is being compiled from source, then it is from post 3.1.0b1, and not some code that was released on in February 2011.

Fixes #474
