### PR TITLE
Avoid using 2.3x the image size worth of memory when no memory is enough

### DIFF
--- a/lib/Imagine/Image/Metadata/ExifMetadataReader.php
+++ b/lib/Imagine/Image/Metadata/ExifMetadataReader.php
@@ -36,6 +36,14 @@ class ExifMetadataReader extends AbstractMetadataReader
      */
     protected function extractFromFile($file)
     {
+        if (stream_is_local($file)) {
+            if (false === is_readable($file)) {
+                throw new InvalidArgumentException(sprintf('File %s is not readable.', $file));
+            }
+
+            return $this->extract($file);
+        }
+
         if (false === $data = @file_get_contents($file)) {
             throw new InvalidArgumentException(sprintf('File %s is not readable.', $file));
         }


### PR DESCRIPTION
exif_read_data can read from the filesystem just fine, so if we get an image path, doing file_get_contents() will load up the file in memory, and then passing it to doReadData will base64_encode it which typically adds 1/3rd of the binary size to the output, so you add 1.3x the image size into the memory. 

This is all fine with thumbnail sized images but when dealing with large files you very easily and unnecessarily blow up the memory limit.

There is no 0.6 branch but this applies cleanly on 0.6.3 as well, in case you'd like to do a new release :)