### PR TITLE
0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
     "psr-0": {
       "Imagine": "lib/"
     }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-develop": "0.5-dev"
+    }
   }
 }

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -147,6 +147,33 @@ final class Image implements ImageInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return ImageInterface
+     */
+    final public function merge(ImageInterface $image, PointInterface $start, $alpha = 100)
+    {
+        if (!$image instanceof self) {
+            throw new InvalidArgumentException(sprintf('Gd\Image can only paste() Gd\Image instances, %s given', get_class($image)));
+        }
+        $size = $image->getSize();
+        if (!$this->getSize()->contains($size, $start)) {
+            throw new OutOfBoundsException('Cannot paste image of the given size at the specified position, as it moves outside of the current image\'s box');
+        }
+ 
+        imagealphablending($this->resource, true);
+        imagealphablending($image->resource, true);
+        
+        if (false === imagecopymerge($this->resource, $image->resource, $start->getX(), $start->getY(), 0, 0, $size->getWidth(), $size->getHeight(), $alpha)) {
+            throw new RuntimeException('Image paste operation failed');
+        }
+        imagealphablending($this->resource, false);
+        imagealphablending($image->resource, false);
+        
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     final public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {


### PR DESCRIPTION
Hello. Sorry for my bad English. When using the library I had to combine the image with the established transparency. I have not found such an opportunity you have. When you insert the image you are using "imagecopy" which does not imply transparency / overlay

I copied the method of "paste" and changed it to "imagecopy -> imagecopymerge"
It is identical, but allows you to specify the transparency. Perhaps the method can "paste" in the implementation of the general update itself, but I decided to just add it to "merge" analog. Some result there I turned only when using both methods together :)

Thank you, no "imagecopymerge" I just could not use your library, the transparency was very important for me.

-- on russian --
Извините за мой плохой английский. При использовании библиотеки мне нужно было совмещать изображения с установленной прозрачностью. Я не нашел такой возможности у вас. При вставке изображения вы используете "imagecopy" которая не подразумевает прозрачности/наложения  

Я скопировал метод "paste" и изменил в нем "imagecopy -> imagecopymerge"
Она идентична, но дает возможность указать прозрачность. Наверное можно в целом обновить саму реализацию метода "paste", но я решил просто добавить его аналог "merge". Какой-то там результат у меня получился только при использовании обоих методов вместе :)

Спасибо, без "imagecopymerge" я просто не мог использовать вашу библиотеку, для меня очень важна была прозрачность. 
