### PR TITLE
If box is a square, providing width is enough

### DIFF
--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -36,8 +36,10 @@ final class Box implements BoxInterface
      *
      * @throws InvalidArgumentException
      */
-    public function __construct($width, $height)
+    public function __construct($width, $height = null)
     {
+        $height = $height ? $height : $width;
+
         if ($height < 1 || $width < 1) {
             throw new InvalidArgumentException(sprintf('Length of either side cannot be 0 or negative, current size is %sx%s', $width, $height));
         }


### PR DESCRIPTION
This pull request provides an option to only provide $width when creating a box and the box is intended to be a square.