### PR TITLE
Double slash for css comment should't be used

### DIFF
--- a/docs/API/API/css/panel.css
+++ b/docs/API/API/css/panel.css
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         background: #FFF;
         z-index: 2;
         font-family: "Helvetica Neue", "Arial", sans-serif;
-        //zoom: 1;
+        /* zoom: 1; */
     }
     
     .panel_tree .results, 
@@ -94,7 +94,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             display: inline-block;
             -webkit-appearance: searchfield;
             height: 22px;
-            //height: auto;
+            /* height: auto; */
         }
         
     /* Header with search box (end) */
@@ -108,13 +108,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             bottom: 0;
             left: 0;
             width: 100%;
-            //height: expression((this.parentNode.offsetHeight - 31));
+            /* height: expression((this.parentNode.offsetHeight - 31)); */
             overflow-y: scroll;
             overflow-x: hidden;
             -overflow-y: hidden;
             background: #EDF3FE url(../i/results_bg.png);
             z-index: 2;
-            //zoom:1;
+            /* zoom:1; */
         }
 
         .panel .result ul
@@ -122,16 +122,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             font-size: 0.8em;
             width: 100%;
             background: #EDF3FE url(../i/results_bg.png);
-            //zoom:1;
+            /* zoom:1; */
         }
 
         .panel .result ul li
         {
             height: 46px;
             -height: 50px;
-            //display: inline;
-            //width: 100%;
-            //zoom: 1;
+            /* display: inline; */
+            /* width: 100%; */
+            /* zoom: 1; */
             overflow: hidden;
             padding: 4px 10px 0 10px;
             cursor: pointer;
@@ -277,8 +277,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             bottom: 0;
             left: 0;
             width: 100%;
-            //zoom: 1;
-            //height: expression((this.parentNode.offsetHeight - 31));
+            /* zoom: 1; */
+            /* height: expression((this.parentNode.offsetHeight - 31)); */
             overflow-y: scroll;
             overflow-x: hidden;
             -overflow-y: hidden;
@@ -295,10 +295,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         {
             cursor: pointer;
             overflow: hidden;
-            //height: 23px;
-            //display: inline;
-            //zoom: 1;
-            //width: 100%;
+            /* height: 23px; */
+            /* display: inline; */
+            /* zoom: 1; */
+            /* width: 100%; */
         }
         
         


### PR DESCRIPTION
Double slash for css comments should't be used.

See http://stackoverflow.com/questions/12298890/is-it-bad-practice-to-comment-out-single-lines-of-css-with
