### PR TITLE
Remove unnecessary PDF from autogenerated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /docs               export-ignore
 /tests              export-ignore
 /lib/Imagine/Test   export-ignore
+/lib/Imagine/resources/Adobe/Profile[[:space:]]Information.pdf export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore


### PR DESCRIPTION
What about removing this (big) PDF from autogenerated ZIP archives?
I don't think it's useful for production machines, developers that need this may still do a `git clone`.

Are the other PDF files needed for legal purposes or can we remove them too?
