### PR TITLE
png compression method changed in imagemagick 6.8.8

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -696,8 +696,15 @@ final class Image extends AbstractImage
             } else {
                 $compression += 5;
             }
-
-            $image->setImageCompressionQuality($compression);
+            $v = \Imagick::getVersion();
+            preg_match('/ImageMagick ([0-9]+\.[0-9]+\.[0-9]+)/', $v['versionString'], $v);
+            if (version_compare($v[1], '6.8.7') < 0 ) {
+                //Use this for ImageMagick releases before 6.8.7-5
+                $image->setImageCompressionQuality($compression);
+            } else {
+            //Use this for ImageMagick releases after 6.8.7-5
+                $image->setCompressionQuality($compression);
+            }
         }
 
         if (isset($options['resolution-units']) && isset($options['resolution-x']) && isset($options['resolution-y'])) {


### PR DESCRIPTION
Looks like starting with imagemagick 6.8.8, you have to use `setCompressionQuality` instead of `setImageCompressionQuality`.
