### PR TITLE
fix for png compression in imagick adapter

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -539,14 +539,6 @@ final class Image extends AbstractImage
         $save = 'image'.$format;
         $args = array(&$this->resource, $filename);
 
-        // Preserve BC until version 1.0
-        if (isset($options['quality']) && !isset($options['png_compression_level'])) {
-            $options['png_compression_level'] = round((100 - $options['quality']) * 9 / 100);
-        }
-        if (isset($options['filters']) && !isset($options['png_compression_filter'])) {
-            $options['png_compression_filter'] = $options['filters'];
-        }
-
         $options = $this->updateSaveOptions($options);
 
         if ($format === 'jpeg' && isset($options['jpeg_quality'])) {

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -96,6 +96,14 @@ abstract class AbstractImage implements ImageInterface
             $options['jpeg_quality'] = $options['quality'];
         }
 
+        if (isset($options['quality']) && !isset($options['png_compression_level'])) {
+            $options['png_compression_level'] = round((100 - $options['quality']) * 9 / 100);
+        }
+
+        if (isset($options['filters']) && !isset($options['png_compression_filter'])) {
+            $options['png_compression_filter'] = $options['filters'];
+        }
+
         return $options;
     }
 


### PR DESCRIPTION
Hi, 
if i understood correctly, there was a little difference in setting the png compression between the gd and the imagick adapter. 
In the imagick adapter the png_compression_level and png_compression_filter were never set by the "quality" parameter. The gd adapter had a different behaviour.
I moved the code from the gd adapter to the AbstractImage class which both extends to ensure that the parameters are correctly set in both cases. It's a change which doesn't break BC in the gd adapter, and the inherent code for handling the compression in the imagick adapter was already there.