### PR TITLE
Fix Imagick 'rotate': reset canvas size after operation

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -337,6 +337,8 @@ final class Image extends AbstractImage
             $pixel = $this->getColor($color);
 
             $this->imagick->rotateimage($pixel, $angle);
+            // Reset the image page: next operations will use the correct canvas size
+            $this->imagick->setImagePage(0, 0, 0, 0);
 
             $pixel->clear();
             $pixel->destroy();


### PR DESCRIPTION
See: http://php.net/manual/en/imagick.rotateimage.php#119455

> Some transformations including Imagick ::rotateImage() may change "image page" -- working area inside the image you work on.
Be careful with future modifications afterwards because the image page would be different from new sizes of the image.
For example, if you do Imagic::cropImage() after rotation, you need to set image page properly, otherwise your crop would be performed relating to wrong coordinates (depending on rotation angle, resulting image size may vary).