### PR TITLE
Revert "png compression method changed in imagemagick 6.8.8"

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -789,15 +789,8 @@ final class Image extends AbstractImage
             } else {
                 $compression += 5;
             }
-            $v = \Imagick::getVersion();
-            preg_match('/ImageMagick ([0-9]+\.[0-9]+\.[0-9]+)/', $v['versionString'], $v);
-            if (version_compare($v[1], '6.8.7') < 0 ) {
-                //Use this for ImageMagick releases before 6.8.7-5
-                $image->setImageCompressionQuality($compression);
-            } else {
-            //Use this for ImageMagick releases after 6.8.7-5
-                $image->setCompressionQuality($compression);
-            }
+
+            $image->setImageCompressionQuality($compression);
         }
 
         if (isset($options['resolution-units']) && isset($options['resolution-x']) && isset($options['resolution-y'])) {


### PR DESCRIPTION
Let's factorize Imagick version detection instead of adding a new parsing