### PR TITLE
Use setImageAlpha instead of deprecated setImageOpacity

### DIFF
--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -81,7 +81,12 @@ final class Imagine extends AbstractImagine
             $imagick->setImageBackgroundColor($pixel);
 
             if (version_compare('6.3.1', $this->getVersion($imagick)) < 0) {
-                $imagick->setImageOpacity($pixel->getColorValue(\Imagick::COLOR_ALPHA));
+                // setImageOpacity was replaced with setImageAlpha in php-imagick v3.4.3
+                if (method_exists($imagick, 'setImageAlpha')) {
+                    $imagick->setImageAlpha($pixel->getColorValue(\Imagick::COLOR_ALPHA));
+                } else {
+                    $imagick->setImageOpacity($pixel->getColorValue(\Imagick::COLOR_ALPHA));
+                }
             }
 
             $pixel->clear();


### PR DESCRIPTION
This fixes a backwards compatibility issue introduced with
v3.4.3 of the php imagick extension. The method has been renamed to
setImageAlpha. See the imagick release notes for more info.

https://pecl.php.net/package-changelog.php?package=imagick&release=3.4.3

Fixes #539