### PR TITLE
Don't unnecessarily copy image in ->thumbnail()

### DIFF
--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -39,7 +39,7 @@ abstract class AbstractImage implements ImageInterface
             $size->getHeight() / $imageSize->getHeight()
         );
 
-        $thumbnail = $this->copy();
+        $thumbnail = $this;
 
         $thumbnail->usePalette($this->palette());
         $thumbnail->strip();


### PR DESCRIPTION
Not sure why it's copying the image again when you generating a thumbnail? Seems like an unnecessary operation....