### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Imagine
+# Imagine
 [![Build Status](https://travis-ci.org/avalanche123/Imagine.svg?branch=develop)](https://travis-ci.org/avalanche123/Imagine)
 
 Tweet about it using the [#php_imagine](https://twitter.com/search?q=%23php_imagine) hashtag.
@@ -6,7 +6,7 @@ Tweet about it using the [#php_imagine](https://twitter.com/search?q=%23php_imag
 Image manipulation library for PHP 5.3 inspired by Python's PIL and other image
 libraries.
 
-##Requirements##
+## Requirements ##
 
 The Imagine library has the following requirements:
 
@@ -21,7 +21,7 @@ Depending on the chosen Image implementation, you may need one of the following:
 ### Installation using composer
 `php composer.phar require imagine/imagine`
 
-##Basic Principles##
+## Basic Principles ##
 
 The main purpose of Imagine is to provide all the necessary functionality to bring all native low level image processing libraries in PHP to the same simple and intuitive OO API.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
