### PR TITLE
fix alpha on rotate (for newer imagemagick versions)

### DIFF
--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -258,7 +258,11 @@ final class Image extends AbstractImage
 
         try {
             $pixel = $this->getColor($color);
-
+            // if the input image doesn't have an alpha channel, we need to add one
+            //  ImageMagick 7 (?) seems not to do that automatically anymore.
+            if ($this->imagick->getImageAlphaChannel() == \Imagick::ALPHACHANNEL_UNDEFINED) {
+                $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_SET);
+            }
             $this->imagick->rotateimage($pixel, $angle);
 
             $pixel->clear();


### PR DESCRIPTION
If the image doesn't have an alpha channel already, newer ImageMagick versions seem not to add that automatically anymore, even when the Pixel has an alpha channel. This fix adds an alphachannel to an image, if there was none before