### PR TITLE
composer: require --dev symfony/phpunit-bridge ^3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "bin-dir": "bin"
     },
     "require": {
-        "php": ">=5.3.2",
-        "symfony/phpunit-bridge": "^3.2"
+        "php": ">=5.3.2"
     },
     "require-dev": {
-        "sami/sami": "^3.3"
+        "sami/sami": "^3.3",
+        "symfony/phpunit-bridge": "^3.2"
     },
     "suggest": {
         "ext-gd": "to use the GD implementation",


### PR DESCRIPTION
PHPUnit Bridge should be a development requirement. I think this change should be issued as a new version as current implementation can break things upstream.

Thanks!