### PR TITLE
Corrections and minor changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ script:
 
 php:
   - 5.3
-    dist: precise
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+matrix:
+  include:
+    - php: 5.3
+      dist: precise  

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 
 php:
   - 5.3
+    dist: precise
   - 5.4
   - 5.5
   - 5.6

--- a/lib/Imagine/Draw/DrawerInterface.php
+++ b/lib/Imagine/Draw/DrawerInterface.php
@@ -57,6 +57,21 @@ interface DrawerInterface
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1);
 
     /**
+     * Draws and circle with center at the given x, y coordinates, and given radius 
+     *
+     * @param PointInterface $center
+     * @param integer        $radius
+     * @param ColorInterface $color
+     * @param Boolean        $fill
+     * @param integer        $thickness
+     *
+     * @throws RuntimeException
+     *
+     * @return DrawerInterface
+     */
+    public function circle(PointInterface $center, $radius, ColorInterface $color, $fill = false, $thickness = 1);
+
+    /**
      * Draws and ellipse with center at the given x, y coordinates, and given
      * width and height
      *
@@ -128,6 +143,21 @@ interface DrawerInterface
      * @return DrawerInterface
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1);
+    
+    /**
+     * Draws a rectangle from left, top(x, y) to right, bottom(x, y) coordinates
+     *
+     * @param PointInterface $leftTop
+     * @param PointInterface $rightBottom
+     * @param ColorInterface $color
+     * @param Boolean        $fill
+     * @param integer        $thickness
+     *
+     * @throws RuntimeException
+     *
+     * @return DrawerInterface
+     */
+    public function rectangle(PointInterface $leftTop, PointInterface $rightBottom, ColorInterface $color, $fill = false, $thickness = 1);
 
     /**
      * Annotates image with specified text at a given position starting on the

--- a/lib/Imagine/Gd/Drawer.php
+++ b/lib/Imagine/Gd/Drawer.php
@@ -51,13 +51,26 @@ final class Drawer implements DrawerInterface
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if (0 === ($thickness = max(1, (int) $thickness))) {
+    		// If $thickness is 0 do nothing (the arc is not going to be drawn):
+    		return $this;
+    	}
+
+    	imagesetthickness($this->resource, $thickness);
 
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Draw arc operation failed');
         }
 
-        if (false === imagearc($this->resource, $center->getX(), $center->getY(), $size->getWidth(), $size->getHeight(), $start, $end, $this->getColor($color))) {
+        if (false === imagearc(
+        	$this->resource,
+        	$center->getX(),
+        	$center->getY(),
+        	$size->getWidth(),
+        	$size->getHeight(),
+        	$start, $end,
+        	$this->getColor($color)
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw arc operation failed');
         }
@@ -76,19 +89,33 @@ final class Drawer implements DrawerInterface
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the polygon is not filled, do nothing (the polygon is not going to be drawn):
+    		return $this;
+    	}
 
-        if ($fill) {
-            $style = IMG_ARC_CHORD;
-        } else {
-            $style = IMG_ARC_CHORD | IMG_ARC_NOFILL;
+    	imagesetthickness($this->resource, $thickness);
+
+    	$style = IMG_ARC_CHORD;
+        if (!$fill) {
+            $style |= IMG_ARC_NOFILL;
         }
 
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Draw chord operation failed');
         }
 
-        if (false === imagefilledarc($this->resource, $center->getX(), $center->getY(), $size->getWidth(), $size->getHeight(), $start, $end, $this->getColor($color), $style)) {
+        if (false === imagefilledarc(
+        	$this->resource,
+        	$center->getX(),
+        	$center->getY(),
+        	$size->getWidth(),
+        	$size->getHeight(),
+        	$start,
+        	$end,
+        	$this->getColor($color),
+        	$style
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw chord operation failed');
         }
@@ -103,9 +130,23 @@ final class Drawer implements DrawerInterface
     /**
      * {@inheritdoc}
      */
+    public function circle(PointInterface $center, $radius, ColorInterface $color, $fill = false, $thickness = 1)
+    {
+    	// GD do not have a circle function, ellipse is used:
+    	return $this->ellipse($center, new Box($radius, $radius), $color, $fill, $thickness);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the ellipse is not filled, do nothing (the ellipse is not going to be drawn):
+    		return $this;
+    	}
+
+    	imagesetthickness($this->resource, $thickness);
 
         if ($fill) {
             $callback = 'imagefilledellipse';
@@ -117,7 +158,14 @@ final class Drawer implements DrawerInterface
             throw new RuntimeException('Draw ellipse operation failed');
         }
 
-        if (false === $callback($this->resource, $center->getX(), $center->getY(), $size->getWidth(), $size->getHeight(), $this->getColor($color))) {
+        if (false === $callback(
+        	$this->resource,
+        	$center->getX(),
+        	$center->getY(),
+        	$size->getWidth(),
+        	$size->getHeight(),
+        	$this->getColor($color)
+		)) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw ellipse operation failed');
         }
@@ -134,13 +182,25 @@ final class Drawer implements DrawerInterface
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $color, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if (0 === ($thickness = max(1, (int) $thickness))) {
+    		// If $thickness is 0 do nothing (the line is not going to be drawn):
+    		return $this;
+    	}
+
+    	imagesetthickness($this->resource, $thickness);
 
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Draw line operation failed');
         }
 
-        if (false === imageline($this->resource, $start->getX(), $start->getY(), $end->getX(), $end->getY(), $this->getColor($color))) {
+        if (false === imageline(
+        	$this->resource,
+        	$start->getX(),
+        	$start->getY(),
+        	$end->getX(),
+        	$end->getY(),
+        	$this->getColor($color)
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw line operation failed');
         }
@@ -157,19 +217,33 @@ final class Drawer implements DrawerInterface
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the ellipse is not filled, do nothing (the ellipse is not going to be drawn):
+    		return $this;
+    	}
 
-        if ($fill) {
-            $style = IMG_ARC_EDGED;
-        } else {
-            $style = IMG_ARC_EDGED | IMG_ARC_NOFILL;
+    	imagesetthickness($this->resource, $thickness);
+
+    	$style = IMG_ARC_EDGED;
+        if (!$fill) {
+            $style != IMG_ARC_NOFILL;
         }
 
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Draw chord operation failed');
         }
 
-        if (false === imagefilledarc($this->resource, $center->getX(), $center->getY(), $size->getWidth(), $size->getHeight(), $start, $end, $this->getColor($color), $style)) {
+        if (false === imagefilledarc(
+        	$this->resource,
+        	$center->getX(),
+        	$center->getY(),
+        	$size->getWidth(),
+        	$size->getHeight(),
+        	$start,
+        	$end,
+        	$this->getColor($color),
+        	$style
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw chord operation failed');
         }
@@ -190,7 +264,12 @@ final class Drawer implements DrawerInterface
             throw new RuntimeException('Draw point operation failed');
         }
 
-        if (false === imagesetpixel($this->resource, $position->getX(), $position->getY(), $this->getColor($color))) {
+        if (false === imagesetpixel(
+        	$this->resource,
+        	$position->getX(),
+        	$position->getY(),
+        	$this->getColor($color)
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw point operation failed');
         }
@@ -207,9 +286,14 @@ final class Drawer implements DrawerInterface
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1)
     {
-        imagesetthickness($this->resource, max(1, (int) $thickness));
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the polygon is not filled, do nothing (the polygon is not going to be drawn):
+    		return $this;
+    	}
 
-        if (count($coordinates) < 3) {
+    	imagesetthickness($this->resource, $thickness);
+
+        if (($coordinatesCount = count($coordinates)) < 3) {
             throw new InvalidArgumentException(sprintf('A polygon must consist of at least 3 points, %d given', count($coordinates)));
         }
 
@@ -227,7 +311,12 @@ final class Drawer implements DrawerInterface
             throw new RuntimeException('Draw polygon operation failed');
         }
 
-        if (false === $callback($this->resource, $points, count($coordinates), $this->getColor($color))) {
+        if (false === $callback(
+        	$this->resource,
+        	$points,
+        	$coordinatesCount,
+        	$this->getColor($color)
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw polygon operation failed');
         }
@@ -237,6 +326,46 @@ final class Drawer implements DrawerInterface
         }
 
         return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function rectangle(PointInterface $leftTop, PointInterface $rightBottom, ColorInterface $color, $fill = false, $thickness = 1)
+    {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the polygon is not filled, do nothing (the polygon is not going to be drawn):
+    		return $this;
+    	}
+    	
+    	imagesetthickness($this->resource, $thickness);
+    	
+    	if ($fill) {
+    		$callback = 'imagefilledrectangle';
+    	} else {
+    		$callback = 'imagerectangle';
+    	}
+    		
+		if (false === imagealphablending($this->resource, true)) {
+    		throw new RuntimeException('Draw rectangle operation failed');
+    	}
+    		
+    	if (false === $callback(
+    		$leftTop->getX(),
+    		$leftTop->getY(),
+    		$rightBottom->getX(),
+    		$rightBottom->getY(),
+    		$this->getColor($color)
+    	)) {
+    		imagealphablending($this->resource, false);
+    		throw new RuntimeException('Draw rectangle operation failed');
+    	}
+    				
+    	if (false === imagealphablending($this->resource, false)) {
+    		throw new RuntimeException('Draw rectangle operation failed');
+    	}
+
+		return $this;
     }
 
     /**
@@ -292,8 +421,13 @@ final class Drawer implements DrawerInterface
             throw new InvalidArgumentException('GD driver only supports RGB colors');
         }
 
-        $gdColor = imagecolorallocatealpha($this->resource, $color->getRed(), $color->getGreen(), $color->getBlue(), (100 - $color->getAlpha()) * 127 / 100);
-        if (false === $gdColor) {
+        if (false === ($gdColor = imagecolorallocatealpha(
+        	$this->resource,
+        	$color->getRed(),
+        	$color->getGreen(),
+        	$color->getBlue(),
+        	(100 - $color->getAlpha()) * 127 / 100
+        ))) {
             throw new RuntimeException(sprintf('Unable to allocate color "RGB(%s, %s, %s)" with transparency of %d percent', $color->getRed(), $color->getGreen(), $color->getBlue(), $color->getAlpha()));
         }
 

--- a/lib/Imagine/Gmagick/Drawer.php
+++ b/lib/Imagine/Gmagick/Drawer.php
@@ -44,6 +44,11 @@ final class Drawer implements DrawerInterface
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1)
     {
+    	if (0 === ($thickness = max(1, (int) $thickness))) {
+    		// If $thickness is 0 do nothing (the arc is not going to be drawn):
+    		return $this;
+    	}
+
         $x      = $center->getX();
         $y      = $center->getY();
         $width  = $size->getWidth();
@@ -52,10 +57,12 @@ final class Drawer implements DrawerInterface
         try {
             $pixel = $this->getColor($color);
             $arc   = new \GmagickDraw();
+            
+            $arc->setstrokewidth($thickness);
+            $this->setStrokeColorOpacity($arc, $pixel)
+            
+            	 ->setFillColorOpacity($arc, 'transparent');
 
-            $arc->setstrokecolor($pixel);
-            $arc->setstrokewidth(max(1, (int) $thickness));
-            $arc->setfillcolor('transparent');
             $arc->arc(
                 $x - $width / 2,
                 $y - $height / 2,
@@ -82,6 +89,11 @@ final class Drawer implements DrawerInterface
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the cord is not filled, do nothing (the chord is not going to be drawn):
+    		return $this;
+    	}
+
         $x      = $center->getX();
         $y      = $center->getY();
         $width  = $size->getWidth();
@@ -91,23 +103,31 @@ final class Drawer implements DrawerInterface
             $pixel = $this->getColor($color);
             $chord = new \GmagickDraw();
 
-            $chord->setstrokecolor($pixel);
-            $chord->setstrokewidth(max(1, (int) $thickness));
+            $chord->setstrokewidth($thickness);
+            $this->setStrokeColorOpacity($chord, 0 === $thickness ? 'transparent' : $pixel);
 
             if ($fill) {
-                $chord->setfillcolor($pixel);
+            	$this->setFillColorOpacity($chord, $pixel);
             } else {
-                $x1 = round($x + $width / 2 * cos(deg2rad($start)));
-                $y1 = round($y + $height / 2 * sin(deg2rad($start)));
-                $x2 = round($x + $width / 2 * cos(deg2rad($end)));
-                $y2 = round($y + $height / 2 * sin(deg2rad($end)));
+            	$start = deg2rad($start);
+            	$end   = deg2rad($end);
+            	$this->line(
+            		new Point(round($x + $width / 2 * cos($start)), round($y + $height / 2 * sin($start))),
+            		new Point(round($x + $width / 2 * cos($end)), round($y + $height / 2 * sin($end))),
+            		$color
+            	);
 
-                $this->line(new Point($x1, $y1), new Point($x2, $y2), $color);
-
-                $chord->setfillcolor('transparent');
+                $this->setFillColorOpacity($chord, 'transparent');
             }
 
-            $chord->arc($x - $width / 2, $y - $height / 2, $x + $width / 2, $y + $height / 2, $start, $end);
+            $chord->arc(
+           		$x - $width / 2,
+            	$y - $height / 2,
+            	$x + $width / 2,
+            	$y + $height / 2,
+            	$start,
+            	$end
+            );
 
             $this->gmagick->drawImage($chord);
 
@@ -120,12 +140,26 @@ final class Drawer implements DrawerInterface
 
         return $this;
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function circle(PointInterface $center, $radius, ColorInterface $color, $fill = false, $thickness = 1)
+    {
+    	// Gmagick do not have a circle function, ellipse is used:
+    	return $this->ellipse($center, new Box($radius, $radius), $color, $fill, $thickness);
+    }
 
     /**
      * {@inheritdoc}
      */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1)
     {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the ellipse is not filled, do nothing (the ellipse is not going to be drawn):
+    		return $this;
+    	}
+
         $width  = $size->getWidth();
         $height = $size->getHeight();
 
@@ -133,14 +167,10 @@ final class Drawer implements DrawerInterface
             $pixel   = $this->getColor($color);
             $ellipse = new \GmagickDraw();
 
-            $ellipse->setstrokecolor($pixel);
-            $ellipse->setstrokewidth(max(1, (int) $thickness));
+            $ellipse->setstrokewidth($thickness);
+            $this->setStrokeColorOpacity($ellipse, 0 === $thickness ? 'transparent' : $pixel)
 
-            if ($fill) {
-                $ellipse->setfillcolor($pixel);
-            } else {
-                $ellipse->setfillcolor('transparent');
-            }
+                 ->setFillColorOpacity($ellipse, $fill ? $pixel : 'transparent');
 
             $ellipse->ellipse(
                 $center->getX(),
@@ -167,13 +197,20 @@ final class Drawer implements DrawerInterface
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $color, $thickness = 1)
     {
+    	if (0 === ($thickness = max(1, (int) $thickness))) {
+    		// If $thickness is 0 do nothing (the line is not going to be drawn):
+    		return $this;
+    	}
+
         try {
             $pixel = $this->getColor($color);
             $line  = new \GmagickDraw();
 
-            $line->setstrokecolor($pixel);
-            $line->setstrokewidth(max(1, (int) $thickness));
-            $line->setfillcolor($pixel);
+            $line->setstrokewidth($thickness);
+            $this->setStrokeColorOpacity($line, $pixel)
+
+                 ->setFillColorOpacity($line, $pixel);
+
             $line->line(
                 $start->getX(),
                 $start->getY(),
@@ -198,6 +235,11 @@ final class Drawer implements DrawerInterface
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the pieSlice is not filled, do nothing (the pieSlice is not going to be drawn):
+    		return $this;
+    	}
+
         $width  = $size->getWidth();
         $height = $size->getHeight();
 
@@ -239,12 +281,14 @@ final class Drawer implements DrawerInterface
             $pixel = $this->getColor($color);
             $point = new \GmagickDraw();
 
-            $point->setfillcolor($pixel);
+            $this->setFillColorOpacity($point, $pixel);
+
             $point->point($x, $y);
 
             $this->gmagick->drawimage($point);
 
             $pixel = null;
+
             $point = null;
         } catch (\GmagickException $e) {
             throw new RuntimeException('Draw point operation failed', $e->getCode(), $e);
@@ -258,6 +302,11 @@ final class Drawer implements DrawerInterface
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1)
     {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the polygon is not filled, do nothing (the polygon is not going to be drawn):
+    		return $this;
+    	}
+
         if (count($coordinates) < 3) {
             throw new InvalidArgumentException(sprintf('Polygon must consist of at least 3 coordinates, %d given', count($coordinates)));
         }
@@ -270,25 +319,61 @@ final class Drawer implements DrawerInterface
             $pixel   = $this->getColor($color);
             $polygon = new \GmagickDraw();
 
-            $polygon->setstrokecolor($pixel);
-            $polygon->setstrokewidth(max(1, (int) $thickness));
+            $polygon->setstrokewidth($thickness);
+            $this->setStrokeColorOpacity($polygon, 0 === $thickness ? 'transparent' : $pixel)
 
-            if ($fill) {
-                $polygon->setfillcolor($pixel);
-            } else {
-                $polygon->setfillcolor('transparent');
-            }
+                 ->setFillColorOpacity($polygon, $fill ? $pixel : 'transparent');
 
             $polygon->polygon($points);
 
             $this->gmagick->drawImage($polygon);
 
-            unset($pixel, $polygon);
+            $pixel   = null;
+            
+            $polygon = null;
         } catch (\GmagickException $e) {
             throw new RuntimeException('Draw polygon operation failed', $e->getCode(), $e);
         }
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rectangle(PointInterface $leftTop, PointInterface $rightBottom, ColorInterface $color, $fill = false, $thickness = 1)
+    {
+    	if ((0 === ($thickness = max(1, (int) $thickness))) && (!$fill)) {
+    		// If $thickness is 0 and the polygon is not filled, do nothing (the polygon is not going to be drawn):
+    		return $this;
+    	}
+    	
+    	try {
+    		$pixel     = $this->getColor($color);
+    		$rectangle = new \GmagickDraw();
+    		
+    		$rectangle->setstrokewidth($thickness);
+    		$this->setStrokeColorOpacity($rectangle, 0 === $thickness ? 'transparent' : $pixel)
+    		
+    		     ->setFillColorOpacity($rectangle, $fill ? $pixel : 'transparent');
+    		
+    		$rectangle->rectangle(
+    			$leftTop->getX(),
+    			$leftTop->getY(),
+    			$rightBottom->getX(),
+    			$rightBottom->getY()
+    		);
+    		
+    		$this->gmagick->drawImage($rectangle);
+    		
+    		$pixel     = null;
+    		
+    		$rectangle = null;
+    	} catch (\ImagickException $e) {
+    		throw new RuntimeException('Draw rectangle operation failed', $e->getCode(), $e);
+    	}
+    	
+    	return $this;
     }
 
     /**
@@ -307,7 +392,7 @@ final class Drawer implements DrawerInterface
              * ensure font resolution is the same as GD's hard-coded 96
              */
             $text->setfontsize((int) ($font->getSize() * (96 / 72)));
-            $text->setfillcolor($pixel);
+            $this->setFillColorOpacity($text, $pixel);
 
             $info = $this->gmagick->queryfontmetrics($text, $string);
             $rad  = deg2rad($angle);
@@ -339,7 +424,7 @@ final class Drawer implements DrawerInterface
     /**
      * Gets specifically formatted color string from Color instance
      *
-     * @param ColorInterface $color
+     * @param  ColorInterface $color
      *
      * @return \GmagickPixel
      *
@@ -352,5 +437,39 @@ final class Drawer implements DrawerInterface
         }
 
         return new \GmagickPixel((string) $color);
+    }
+    
+    /**
+     * Set color and opacity (0 if === 'transparent', 1 if !== 'transparent') of a fill
+     *
+     * @param  \GmagickDraw         $draw
+     * @param  string|\GmagickPixel $pixel
+     *
+     * @return DrawerInterface
+     */
+    private function setFillColorOpacity(\GmagickDraw $draw, $pixel)
+    {
+    	$draw->setfillcolor($pixel);
+    	// Ensure that the stroke is visible:
+    	$draw->setfillopacity('transparent' === $pixel ? 0 : 1);
+    	
+    	return $this;
+    }
+    
+    /**
+     * Set color and opacity (0 if === 'transparent', 1 if !== 'transparent') of a stroke
+     *
+     * @param  \GmagickDraw         $draw
+     * @param  string|\GmagickPixel $pixel
+     *
+     * @return DrawerInterface
+     */
+    private function setStrokeColorOpacity(\GmagickDraw $draw, $pixel)
+    {
+    	$draw->setstrokecolor($pixel);
+    	// Ensure that the stroke is visible:
+    	$draw->setstrokeopacity('transparent' === $pixel ? 0 : 1);
+    	
+    	return $this;
     }
 }

--- a/lib/Imagine/Image/Box.php
+++ b/lib/Imagine/Image/Box.php
@@ -75,7 +75,14 @@ final class Box implements BoxInterface
      */
     public function increase($size)
     {
-        return new Box((int) $size + $this->width, (int) $size + $this->height);
+    	if ($size instanceof BoxInterface) {
+    		$sizeWidth  = $size->getWidth();
+    		$sizeHeight = $size->getHeight();
+    	} else {
+    		$sizeWidth = $sizeHeight = (int) $size;
+    	}
+    	
+    	return new Box($sizeWidth + $this->width, $sizeHeight + $this->height);
     }
 
     /**

--- a/lib/Imagine/Image/BoxInterface.php
+++ b/lib/Imagine/Image/BoxInterface.php
@@ -42,7 +42,7 @@ interface BoxInterface
     /**
      * Creates new BoxInterface, adding given size to both sides
      *
-     * @param integer $size
+     * @param integer|BoxInterface $size
      *
      * @return BoxInterface
      */
@@ -53,6 +53,7 @@ interface BoxInterface
      * start position defaults to top left corner xy(0,0)
      *
      * @param BoxInterface   $box
+     * 
      * @param PointInterface $start
      *
      * @return Boolean

--- a/lib/Imagine/Image/Point.php
+++ b/lib/Imagine/Image/Point.php
@@ -75,7 +75,14 @@ final class Point implements PointInterface
      */
     public function move($amount)
     {
-        return new Point($this->x + $amount, $this->y + $amount);
+    	if ($amount instanceof BoxInterface) {
+    		$amountX = $amount->getWidth();
+    		$amountY = $amount->getHeight();
+    	} else {
+    		$amountX = $amountY= (int) $amount;
+    	}
+
+    	return new Point($amountX + $this->x, $amountY + $this->y);
     }
 
     /**

--- a/lib/Imagine/Image/Point/Center.php
+++ b/lib/Imagine/Image/Point/Center.php
@@ -71,7 +71,7 @@ final class Center implements PointInterface
     		$amountX = $amountY= (int) $amount;
     	}
 
-    	return new Point($amountX + $this->x, $amountY + $this->y);
+    	return new OriginalPoint($amountX + $this->x, $amountY + $this->y);
     }
 
     /**

--- a/lib/Imagine/Image/Point/Center.php
+++ b/lib/Imagine/Image/Point/Center.php
@@ -71,7 +71,7 @@ final class Center implements PointInterface
     		$amountX = $amountY= (int) $amount;
     	}
 
-    	return new OriginalPoint($amountX + $this->x, $amountY + $this->y);
+    	return new OriginalPoint($this->getX() + $amountX, $this->getY() + $amountY);
     }
 
     /**

--- a/lib/Imagine/Image/Point/Center.php
+++ b/lib/Imagine/Image/Point/Center.php
@@ -64,7 +64,14 @@ final class Center implements PointInterface
      */
     public function move($amount)
     {
-        return new OriginalPoint($this->getX() + $amount, $this->getY() + $amount);
+    	if ($amount instanceof BoxInterface) {
+    		$amountX = $amount->getWidth();
+    		$amountY = $amount->getHeight();
+    	} else {
+    		$amountX = $amountY= (int) $amount;
+    	}
+
+    	return new Point($amountX + $this->x, $amountY + $this->y);
     }
 
     /**

--- a/lib/Imagine/Image/PointInterface.php
+++ b/lib/Imagine/Image/PointInterface.php
@@ -42,7 +42,8 @@ interface PointInterface
     /**
      * Returns another point, moved by a given amount from current coordinates
      *
-     * @param  integer        $amount
+     * @param  integer|BoxInterface $amount
+     * 
      * @return ImageInterface
      */
     public function move($amount);


### PR DESCRIPTION
List of corrections/changes:
- circle and rectangle methods added to drawers.
- For Gmagick and Imagick set stroke and fill opacity ('transparent' ? 0 : 1), in imagick (6.9.3-7) filled polygon was not draw if the fill opacity is not set.
- For Point and Center: move accepts now a box as parameter, this allow to move the point in two dimensions.
- For Box: increase accept a box this allow increase the size in two dimensions.