### PR TITLE
Required for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 
 php:
   - 5.3
+    dist: precise
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
PHP-images is NOT compatible with PHP 5.3, Precise is required.

See: https://docs.travis-ci.com/user/reference/trusty#PHP-images