### PR TITLE
Allow PHPUnit 6 and PHP 7.2 tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "sami/sami": "^3.3",
-        "symfony/phpunit-bridge": "^3.2"
+        "symfony/phpunit-bridge": "^4"
     },
     "suggest": {
         "ext-gd": "to use the GD implementation",

--- a/tests/Imagine/Test/Constraint/IsImageEqual.php
+++ b/tests/Imagine/Test/Constraint/IsImageEqual.php
@@ -15,6 +15,10 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\Histogram\Bucket;
 use Imagine\Image\Histogram\Range;
 
+if (!class_exists('PHPUnit_Framework_Constraint')) {
+    class_alias('\PHPUnit\Framework\Constraint\Constraint', 'PHPUnit_Framework_Constraint');
+}
+
 class IsImageEqual extends \PHPUnit_Framework_Constraint
 {
     /**

--- a/tests/Imagine/Test/Effects/AbstractEffectsTest.php
+++ b/tests/Imagine/Test/Effects/AbstractEffectsTest.php
@@ -16,7 +16,7 @@ use Imagine\Image\Point;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Palette\RGB;
 
-abstract class AbstractEffectsTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractEffectsTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testNegate()

--- a/tests/Imagine/Test/Filter/FilterTestCase.php
+++ b/tests/Imagine/Test/Filter/FilterTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Imagine\Test\Filter;
 
-abstract class FilterTestCase extends \PHPUnit_Framework_TestCase
+abstract class FilterTestCase extends \PHPUnit\Framework\TestCase
 {
     protected function getImage()
     {

--- a/tests/Imagine/Test/Functional/GdTransparentGifHandlingTest.php
+++ b/tests/Imagine/Test/Functional/GdTransparentGifHandlingTest.php
@@ -15,7 +15,7 @@ use Imagine\Image\Point;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
-class GdTransparentGifHandlingTest extends \PHPUnit_Framework_TestCase
+class GdTransparentGifHandlingTest extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()
     {

--- a/tests/Imagine/Test/Gmagick/EffectsTest.php
+++ b/tests/Imagine/Test/Gmagick/EffectsTest.php
@@ -27,7 +27,7 @@ class EffectsTest extends AbstractEffectsTest
 
     public function testColorize()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('RuntimeException');
         parent::testColorize();
     }
 

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -138,7 +138,7 @@ abstract class AbstractImageTest extends ImagineTestCase
     public function testSaveWithoutPathFileFromImageCreationShouldFail()
     {
         $image = $this->getImagine()->create(new Box(20, 20));
-        $this->setExpectedException('Imagine\Exception\RuntimeException');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Imagine\Exception\RuntimeException');
         $image->save();
     }
 
@@ -230,7 +230,7 @@ abstract class AbstractImageTest extends ImagineTestCase
         $factory = $this->getImagine();
         $image = $factory->open('tests/Imagine/Fixtures/google.png');
 
-        $this->setExpectedException('Imagine\Exception\InvalidArgumentException');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Imagine\Exception\InvalidArgumentException');
         $image->resize(new Box(30, 30), 'no filter');
     }
 
@@ -270,7 +270,7 @@ abstract class AbstractImageTest extends ImagineTestCase
     {
         $factory = $this->getImagine();
         $image = $factory->open('tests/Imagine/Fixtures/google.png');
-        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', 'Invalid mode specified');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Imagine\Exception\InvalidArgumentException', 'Invalid mode specified');
         $image->thumbnail(new Box(20, 20), "boumboum");
     }
 

--- a/tests/Imagine/Test/Image/AbstractImagineTest.php
+++ b/tests/Imagine/Test/Image/AbstractImagineTest.php
@@ -70,7 +70,7 @@ abstract class AbstractImagineTest extends ImagineTestCase
     {
         $invalidResource = __DIR__.'/path/that/does/not/exist';
 
-        $this->setExpectedException('Imagine\Exception\InvalidArgumentException', sprintf('File %s does not exist.', $invalidResource));
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Imagine\Exception\InvalidArgumentException', sprintf('File %s does not exist.', $invalidResource));
         $this->getImagine()->open($invalidResource);
     }
 
@@ -78,7 +78,7 @@ abstract class AbstractImagineTest extends ImagineTestCase
     {
         $source = 'tests/Imagine/Fixtures/invalid-image.jpg';
 
-        $this->setExpectedException('Imagine\Exception\RuntimeException', sprintf('Unable to open image %s', $source));
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Imagine\Exception\RuntimeException', sprintf('Unable to open image %s', $source));
         $this->getImagine()->open($source);
     }
 

--- a/tests/Imagine/Test/Image/AbstractLayersTest.php
+++ b/tests/Imagine/Test/Image/AbstractLayersTest.php
@@ -18,7 +18,7 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Image\ImagineInterface;
 
-abstract class AbstractLayersTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractLayersTest extends \PHPUnit\Framework\TestCase
 {
     public function testMerge()
     {

--- a/tests/Imagine/Test/Image/BoxTest.php
+++ b/tests/Imagine/Test/Image/BoxTest.php
@@ -16,7 +16,7 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\Box;
 use Imagine\Image\Point;
 
-class BoxTest extends \PHPUnit_Framework_TestCase
+class BoxTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Imagine\Image\Box::getWidth

--- a/tests/Imagine/Test/Image/Fill/Gradient/LinearTest.php
+++ b/tests/Imagine/Test/Image/Fill/Gradient/LinearTest.php
@@ -15,7 +15,7 @@ use Imagine\Image\Palette\RGB;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\PointInterface;
 
-abstract class LinearTest extends \PHPUnit_Framework_TestCase
+abstract class LinearTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Imagine\Image\Fill\FillInterface

--- a/tests/Imagine/Test/Image/Histogram/BucketTest.php
+++ b/tests/Imagine/Test/Image/Histogram/BucketTest.php
@@ -14,7 +14,7 @@ namespace Imagine\Test\Image\Histogram;
 use Imagine\Image\Histogram\Bucket;
 use Imagine\Image\Histogram\Range;
 
-class BucketTest extends \PHPUnit_Framework_TestCase
+class BucketTest extends \PHPUnit\Framework\TestCase
 {
     private $bucket;
 

--- a/tests/Imagine/Test/Image/Histogram/RangeTest.php
+++ b/tests/Imagine/Test/Image/Histogram/RangeTest.php
@@ -13,7 +13,7 @@ namespace Imagine\Test\Image\Histogram;
 
 use Imagine\Image\Histogram\Range;
 
-class RangeTest extends \PHPUnit_Framework_TestCase
+class RangeTest extends \PHPUnit\Framework\TestCase
 {
     private $start = 0;
     private $end   = 63;

--- a/tests/Imagine/Test/Image/Metadata/MetadataBagTest.php
+++ b/tests/Imagine/Test/Image/Metadata/MetadataBagTest.php
@@ -13,7 +13,7 @@ namespace Imagine\Test\Image\Metadata;
 
 use Imagine\Image\Metadata\MetadataBag;
 
-class MetadataBagTest extends \PHPUnit_Framework_TestCase
+class MetadataBagTest extends \PHPUnit\Framework\TestCase
 {
     public function testArrayAccessImplementation()
     {

--- a/tests/Imagine/Test/Image/Point/CenterTest.php
+++ b/tests/Imagine/Test/Image/Point/CenterTest.php
@@ -17,7 +17,7 @@ use Imagine\Image\PointInterface;
 use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
 
-class CenterTest extends \PHPUnit_Framework_TestCase
+class CenterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Imagine\Image\Point\Center::getX

--- a/tests/Imagine/Test/Image/PointTest.php
+++ b/tests/Imagine/Test/Image/PointTest.php
@@ -15,7 +15,7 @@ use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Point;
 
-class PointTest extends \PHPUnit_Framework_TestCase
+class PointTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Imagine\Image\Point::getX

--- a/tests/Imagine/Test/ImagineTestCase.php
+++ b/tests/Imagine/Test/ImagineTestCase.php
@@ -13,7 +13,7 @@ namespace Imagine\Test;
 
 use Imagine\Test\Constraint\IsImageEqual;
 
-class ImagineTestCase extends \PHPUnit_Framework_TestCase
+class ImagineTestCase extends \PHPUnit\Framework\TestCase
 {
     const HTTP_IMAGE = 'http://imagine.readthedocs.org/en/latest/_static/logo.jpg';
 

--- a/tests/Imagine/Test/Issues/Issue131Test.php
+++ b/tests/Imagine/Test/Issues/Issue131Test.php
@@ -6,7 +6,7 @@ use Imagine\Imagick\Imagine as ImagickImagine;
 use Imagine\Gmagick\Imagine as GmagickImagine;
 use Imagine\Exception\RuntimeException;
 
-class Issue131Test extends \PHPUnit_Framework_TestCase
+class Issue131Test extends \PHPUnit\Framework\TestCase
 {
 
     private function getTemporaryDir()

--- a/tests/Imagine/Test/Issues/Issue17Test.php
+++ b/tests/Imagine/Test/Issues/Issue17Test.php
@@ -7,7 +7,7 @@ use Imagine\Image\Box;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
-class Issue17Test extends \PHPUnit_Framework_TestCase
+class Issue17Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()
     {

--- a/tests/Imagine/Test/Issues/Issue59Test.php
+++ b/tests/Imagine/Test/Issues/Issue59Test.php
@@ -5,7 +5,7 @@ namespace Imagine\Test\Issues;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
-class Issue59Test extends \PHPUnit_Framework_TestCase
+class Issue59Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()
     {

--- a/tests/Imagine/Test/Issues/Issue67Test.php
+++ b/tests/Imagine/Test/Issues/Issue67Test.php
@@ -5,7 +5,7 @@ namespace Imagine\Test\Issues;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
-class Issue67Test extends \PHPUnit_Framework_TestCase
+class Issue67Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()
     {


### PR DESCRIPTION
This PR allow use PHPUnit 6 on PHP 7.x and successfully test PHP 5.3 - PHP 7.2.
Until #581 is merged you can see all green TravisCI status on my fork https://travis-ci.org/dmarkowicz/Imagine/builds/338289404, build on top #581.