### PR TITLE
Fix incorrect alpha instructions for setting (background) colors

### DIFF
--- a/docs/usage/introduction.rst
+++ b/docs/usage/introduction.rst
@@ -136,8 +136,20 @@ You can optionally specify the fill color for the new image, which defaults to o
 
    $palette = new Imagine\Image\Palette\RGB();
    $size  = new Imagine\Image\Box(400, 300);
-   $color = $palette->color('#000', 100);
+   $color = $palette->color('#000', 0);
    $image = $imagine->create($size, $color);
+   
+To use a solid background color, for example orange, provide an alpha of 100.
+
+.. code-block:: php
+
+   <?php
+
+   $palette = new Imagine\Image\Palette\RGB();
+   $size  = new Imagine\Image\Box(400, 300);
+   $color = $palette->color('#ff9900', 100);
+   $image = $imagine->create($size, $color);
+
 
 Save Images
 +++++++++++


### PR DESCRIPTION
The basic introduction said to use alpha 100, but it should be using alpha 0 for transparent. I also added a second example with a solid color. 