### PR TITLE
Use memory stream instead of output buffering

### DIFF
--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -254,10 +254,13 @@ final class Image extends AbstractImage
      */
     public function get($format, array $options = array())
     {
-        ob_start();
-        $this->saveOrOutput($format, $options);
+        $stream = fopen('php://memory', 'wb+');
 
-        return ob_get_clean();
+        $this->saveOrOutput($format, $options, $stream);
+
+        rewind($stream);
+
+        return stream_get_contents($stream);
     }
 
     /**
@@ -521,14 +524,14 @@ final class Image extends AbstractImage
      *
      * Performs save or show operation using one of GD's image... functions
      *
-     * @param string $format
-     * @param array  $options
-     * @param string $filename
+     * @param string               $format
+     * @param array                $options
+     * @param string|resource|null $destination Outputs to STDOUT if null.
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    private function saveOrOutput($format, array $options, $filename = null)
+    private function saveOrOutput($format, array $options, $destination = null)
     {
         $format = $this->normalizeFormat($format);
 
@@ -537,7 +540,7 @@ final class Image extends AbstractImage
         }
 
         $save = 'image'.$format;
-        $args = array(&$this->resource, $filename);
+        $args = array(&$this->resource, $destination);
 
         // Preserve BC until version 1.0
         if (isset($options['quality']) && !isset($options['png_compression_level'])) {


### PR DESCRIPTION
This PR avoids using the output buffer to capture GD output by writing image data to an in-memory stream. Not terribly different, but cleaner IMO and avoids any possible issues surrounding output buffering.