### PR TITLE
Remove not-supported exception for image option

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -287,10 +287,6 @@ final class Image extends AbstractImage
             $image->setCompressionQuality($options['webp_quality']);
         }
 
-        if (isset($options['webp_lossless']) && in_array($format, array('webp'))) {
-            throw new NotSupportedException('Gmagick does not support webp_lossless option');
-        }
-
         if ((isset($options['png_compression_level']) || isset($options['png_compression_filter'])) && $format === 'png') {
             // first digit: compression level (default: 7)
             if (isset($options['png_compression_level'])) {


### PR DESCRIPTION
There are some image options that are only supported by some adapters and in the past these always got ignored.

With #504 a `NotSupportedException` was added for the `webp_lossless` option in the Gmagick adapter (but not the GD adapter). That was probably a mistake? If so, I think we should remove the exception.

/cc @chregu @alexander-schranz