### PR TITLE
Catch exif_read_data exceptions

### DIFF
--- a/lib/Imagine/Image/Metadata/ExifMetadataReader.php
+++ b/lib/Imagine/Image/Metadata/ExifMetadataReader.php
@@ -90,11 +90,15 @@ class ExifMetadataReader extends AbstractMetadataReader
      *
      * @param string $path The path to the file or the data-URI representation.
      *
-     * @return MetadataBag
+     * @return MetadataBag|array
      */
     private function extract($path)
     {
-        if (false === $exifData = @exif_read_data($path, null, true, false)) {
+        try {
+            if (false === $exifData = @exif_read_data($path, null, true, false)) {
+                return array();
+            }
+        } catch (\Exception $e) {
             return array();
         }
 


### PR DESCRIPTION
Instead of throwing exceptions
when exif_read_data fails, just
catch the exception and return
empty array.