### PR TITLE
Add jpeg_sampling_factors option

### DIFF
--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -289,6 +289,14 @@ final class Image extends AbstractImage
                 if (isset($options['jpeg_quality'])) {
                     $image->setCompressionQuality($options['jpeg_quality']);
                 }
+                if (isset($options['jpeg_sampling_factors'])) {
+                    if (!is_array($options['jpeg_sampling_factors']) || \count($options['jpeg_sampling_factors']) < 1) {
+                        throw new InvalidArgumentException('jpeg_sampling_factors option should be an array of integers');
+                    }
+                    $image->setSamplingFactors(array_map(function($factor) {
+                        return (int) $factor;
+                    }, $options['jpeg_sampling_factors']));
+                }
                 break;
             case 'png':
                 if (!isset($options['png_compression_level'])) {

--- a/lib/Imagine/Imagick/Image.php
+++ b/lib/Imagine/Imagick/Image.php
@@ -696,6 +696,14 @@ final class Image extends AbstractImage
                 if (isset($options['jpeg_quality'])) {
                     $image->setImageCompressionQuality($options['jpeg_quality']);
                 }
+                if (isset($options['jpeg_sampling_factors'])) {
+                    if (!is_array($options['jpeg_sampling_factors']) || \count($options['jpeg_sampling_factors']) < 1) {
+                        throw new InvalidArgumentException('jpeg_sampling_factors option should be an array of integers');
+                    }
+                    $image->setSamplingFactors(array_map(function($factor) {
+                        return (int) $factor;
+                    }, $options['jpeg_sampling_factors']));
+                }
                 break;
             case 'png':
                 if (!isset($options['png_compression_level'])) {

--- a/tests/Imagine/Test/Gd/ImageTest.php
+++ b/tests/Imagine/Test/Gd/ImageTest.php
@@ -128,7 +128,16 @@ class ImageTest extends AbstractImageTest
         $this->markTestSkipped('GD driver only supports 72 dpi resolution');
     }
 
+    public function testJpegSamplingFactors()
+    {
+        $this->markTestSkipped('GD driver does not support JPEG sampling factors');
+    }
+
     protected function getImageResolution(ImageInterface $image)
+    {
+    }
+
+    protected function getSamplingFactors(ImageInterface $image)
     {
     }
 }

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -93,4 +93,9 @@ class ImageTest extends AbstractImageTest
     {
         return $image->getGmagick()->getimageresolution();
     }
+
+    protected function getSamplingFactors(ImageInterface $image)
+    {
+        return $image->getGmagick()->getSamplingFactors();
+    }
 }

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -774,6 +774,23 @@ abstract class AbstractImageTest extends ImagineTestCase
         );
     }
 
+    public function testJpegSamplingFactors()
+    {
+        $image = $this->getImagine()->open('tests/Imagine/Fixtures/large.jpg');
+
+        $samplings = [
+            [1, 1, 1],
+            [2, 1, 1],
+        ];
+
+        foreach($samplings as $sampling) {
+            $image->save(__DIR__ . '/tmp.jpg', ['jpeg_sampling_factors' => $sampling]);
+            $this->assertEquals($sampling, $this->getSamplingFactors($image));
+        }
+
+        unlink(__DIR__ . '/tmp.jpg');
+    }
+
     abstract protected function getImageResolution(ImageInterface $image);
 
     private function getMonoLayeredImage()
@@ -813,4 +830,9 @@ abstract class AbstractImageTest extends ImagineTestCase
      * @return boolean
      */
     abstract protected function supportMultipleLayers();
+
+    /**
+     * @return array
+     */
+    abstract protected function getSamplingFactors(ImageInterface $image);
 }

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -778,13 +778,13 @@ abstract class AbstractImageTest extends ImagineTestCase
     {
         $image = $this->getImagine()->open('tests/Imagine/Fixtures/large.jpg');
 
-        $samplings = [
-            [1, 1, 1],
-            [2, 1, 1],
-        ];
+        $samplings = array(
+            array(1, 1, 1),
+            array(2, 1, 1),
+        );
 
         foreach($samplings as $sampling) {
-            $image->save(__DIR__ . '/tmp.jpg', ['jpeg_sampling_factors' => $sampling]);
+            $image->save(__DIR__ . '/tmp.jpg', array('jpeg_sampling_factors' => $sampling));
             $this->assertEquals($sampling, $this->getSamplingFactors($image));
         }
 

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -140,4 +140,9 @@ class ImageTest extends AbstractImageTest
     {
         return $image->getImagick()->getImageResolution();
     }
+
+    protected function getSamplingFactors(ImageInterface $image)
+    {
+        return $image->getImagick()->getSamplingFactors();
+    }
 }


### PR DESCRIPTION
It is currently not possible to specify the sampling factors when saving a JPEG image. This pull request adds the option `jpeg_sampling_factors` to make that possible.