### PR TITLE
Set the current working directory for tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,3 +15,5 @@ if (intval(ini_get('memory_limit')) < 64) {
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 $loader->add('Imagine\Test', __DIR__);
+
+chdir(dirname(__DIR__));


### PR DESCRIPTION
Tests use relative paths to locate fixtures, and assume that the current working directory is the project root.