### PR TITLE
Don't try to execute tests that will be skipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ before_install:
 install:
   - sudo apt-get remove -y imagemagick libmagickcore-dev libmagickwand-dev
   - sudo apt-get install -y libtiff-dev libjpeg-dev libdjvulibre-dev libwmf-dev pkg-config liblcms2-dev
-  - if [[ $IMAGINE_DRIVER = imagick ]]; then ./.travis/imagick.sh; fi
-  - if [[ $IMAGINE_DRIVER = gmagick ]]; then ./.travis/gmagick.sh; fi
+  - PHPUNIT_EXCLUDED_GROUPS=none
+  - if test "${IMAGINE_DRIVER}" = 'imagick'; then ./.travis/imagick.sh; else PHPUNIT_EXCLUDED_GROUPS="${PHPUNIT_EXCLUDED_GROUPS},ext-imagick"; fi
+  - if test "${IMAGINE_DRIVER}" = 'gmagick'; then ./.travis/gmagick.sh; else PHPUNIT_EXCLUDED_GROUPS="${PHPUNIT_EXCLUDED_GROUPS},ext-gmagick"; fi
   - composer install
 
 script:
-  - ./bin/simple-phpunit
+  - ./bin/simple-phpunit --exclude-group "${PHPUNIT_EXCLUDED_GROUPS}" --verbose
 
 php:
   - 5.4

--- a/tests/Imagine/Test/Functional/GdTransparentGifHandlingTest.php
+++ b/tests/Imagine/Test/Functional/GdTransparentGifHandlingTest.php
@@ -15,6 +15,9 @@ use Imagine\Image\Point;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * @group ext-gd
+ */
 class GdTransparentGifHandlingTest extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()

--- a/tests/Imagine/Test/Gd/DrawerTest.php
+++ b/tests/Imagine/Test/Gd/DrawerTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Gd;
 use Imagine\Gd\Imagine;
 use Imagine\Test\Draw\AbstractDrawerTest;
 
+/**
+ * @group ext-gd
+ */
 class DrawerTest extends AbstractDrawerTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gd/EffectsTest.php
+++ b/tests/Imagine/Test/Gd/EffectsTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Gd;
 use Imagine\Gd\Imagine;
 use Imagine\Test\Effects\AbstractEffectsTest;
 
+/**
+ * @group ext-gd
+ */
 class EffectsTest extends AbstractEffectsTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gd/ImageTest.php
+++ b/tests/Imagine/Test/Gd/ImageTest.php
@@ -16,6 +16,9 @@ use Imagine\Test\Image\AbstractImageTest;
 use Imagine\Image\ImageInterface;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * @group ext-gd
+ */
 class ImageTest extends AbstractImageTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gd/ImagineTest.php
+++ b/tests/Imagine/Test/Gd/ImagineTest.php
@@ -15,6 +15,9 @@ use Imagine\Gd\Imagine;
 use Imagine\Test\Image\AbstractImagineTest;
 use Imagine\Image\Box;
 
+/**
+ * @group ext-gd
+ */
 class ImagineTest extends AbstractImagineTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gd/LayersTest.php
+++ b/tests/Imagine/Test/Gd/LayersTest.php
@@ -19,6 +19,9 @@ use Imagine\Test\Image\AbstractLayersTest;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Palette\RGB;
 
+/**
+ * @group ext-gd
+ */
 class LayersTest extends AbstractLayersTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gmagick/DrawerTest.php
+++ b/tests/Imagine/Test/Gmagick/DrawerTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Gmagick;
 use Imagine\Gmagick\Imagine;
 use Imagine\Test\Draw\AbstractDrawerTest;
 
+/**
+ * @group ext-gmagick
+ */
 class DrawerTest extends AbstractDrawerTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gmagick/EffectsTest.php
+++ b/tests/Imagine/Test/Gmagick/EffectsTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Gmagick;
 use Imagine\Gmagick\Imagine;
 use Imagine\Test\Effects\AbstractEffectsTest;
 
+/**
+ * @group ext-gmagick
+ */
 class EffectsTest extends AbstractEffectsTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -16,6 +16,9 @@ use Imagine\Image\ImageInterface;
 use Imagine\Image\Point;
 use Imagine\Test\Image\AbstractImageTest;
 
+/**
+ * @group ext-gmagick
+ */
 class ImageTest extends AbstractImageTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gmagick/ImagineTest.php
+++ b/tests/Imagine/Test/Gmagick/ImagineTest.php
@@ -15,6 +15,9 @@ use Imagine\Gmagick\Imagine;
 use Imagine\Test\Image\AbstractImagineTest;
 use Imagine\Image\Box;
 
+/**
+ * @group ext-gmagick
+ */
 class ImagineTest extends AbstractImagineTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Gmagick/LayersTest.php
+++ b/tests/Imagine/Test/Gmagick/LayersTest.php
@@ -19,6 +19,9 @@ use Imagine\Test\Image\AbstractLayersTest;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Palette\RGB;
 
+/**
+ * @group ext-gmagick
+ */
 class LayersTest extends AbstractLayersTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Image/Palette/ColorParserTest.php
+++ b/tests/Imagine/Test/Image/Palette/ColorParserTest.php
@@ -29,6 +29,7 @@ class ColorParserTest extends ImagineTestCase
     /**
      * @dataProvider provideRGBdataThatFail
      * @expectedException Imagine\Exception\InvalidArgumentException
+     * @group ext-gd
      */
     public function testParseToRGBThatFails($value)
     {
@@ -49,6 +50,7 @@ class ColorParserTest extends ImagineTestCase
     /**
      * @dataProvider provideCMYKdataThatFail
      * @expectedException Imagine\Exception\InvalidArgumentException
+     * @group ext-gd
      */
     public function testParseToCMYKThatFails($value)
     {

--- a/tests/Imagine/Test/Imagick/DrawerTest.php
+++ b/tests/Imagine/Test/Imagick/DrawerTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Imagick;
 use Imagine\Imagick\Imagine;
 use Imagine\Test\Draw\AbstractDrawerTest;
 
+/**
+ * @group ext-imagick
+ */
 class DrawerTest extends AbstractDrawerTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Imagick/EffectsTest.php
+++ b/tests/Imagine/Test/Imagick/EffectsTest.php
@@ -14,6 +14,9 @@ namespace Imagine\Test\Imagick;
 use Imagine\Imagick\Imagine;
 use Imagine\Test\Effects\AbstractEffectsTest;
 
+/**
+ * @group ext-imagick
+ */
 class EffectsTest extends AbstractEffectsTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -21,6 +21,9 @@ use Imagine\Image\Palette\RGB;
 use Imagine\Test\Image\AbstractImageTest;
 use Imagine\Image\Box;
 
+/**
+ * @group ext-imagick
+ */
 class ImageTest extends AbstractImageTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Imagick/ImagineTest.php
+++ b/tests/Imagine/Test/Imagick/ImagineTest.php
@@ -15,6 +15,9 @@ use Imagine\Imagick\Imagine;
 use Imagine\Test\Image\AbstractImagineTest;
 use Imagine\Image\Box;
 
+/**
+ * @group ext-imagick
+ */
 class ImagineTest extends AbstractImagineTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Imagick/LayersTest.php
+++ b/tests/Imagine/Test/Imagick/LayersTest.php
@@ -18,6 +18,9 @@ use Imagine\Imagick\Imagine;
 use Imagine\Test\Image\AbstractLayersTest;
 use Imagine\Image\Palette\RGB;
 
+/**
+ * @group ext-imagick
+ */
 class LayersTest extends AbstractLayersTest
 {
     protected function setUp()

--- a/tests/Imagine/Test/Issues/Issue131Test.php
+++ b/tests/Imagine/Test/Issues/Issue131Test.php
@@ -56,6 +56,9 @@ class Issue131Test extends \PHPUnit\Framework\TestCase
         return $image;
     }
 
+    /**
+     * @group ext-imagick
+     */
     public function testShouldSaveOneFileWithImagick()
     {
         $dir = realpath($this->getTemporaryDir());
@@ -70,6 +73,9 @@ class Issue131Test extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * @group ext-gmagick
+     */
     public function testShouldSaveOneFileWithGmagick()
     {
         $dir = realpath($this->getTemporaryDir());

--- a/tests/Imagine/Test/Issues/Issue17Test.php
+++ b/tests/Imagine/Test/Issues/Issue17Test.php
@@ -7,6 +7,9 @@ use Imagine\Image\Box;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * @group ext-gd
+ */
 class Issue17Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()

--- a/tests/Imagine/Test/Issues/Issue59Test.php
+++ b/tests/Imagine/Test/Issues/Issue59Test.php
@@ -5,6 +5,9 @@ namespace Imagine\Test\Issues;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * @group ext-gd
+ */
 class Issue59Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()

--- a/tests/Imagine/Test/Issues/Issue67Test.php
+++ b/tests/Imagine/Test/Issues/Issue67Test.php
@@ -5,6 +5,9 @@ namespace Imagine\Test\Issues;
 use Imagine\Gd\Imagine;
 use Imagine\Exception\RuntimeException;
 
+/**
+ * @group ext-gd
+ */
 class Issue67Test extends \PHPUnit\Framework\TestCase
 {
     private function getImagine()


### PR DESCRIPTION
So that we don't have tons of skipped tests listed when phpunit is executed with --verbose