### PR TITLE
Force loading of palette profiles in testPaletteAssociatedIsRelatedToGivenColor

### DIFF
--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -52,6 +52,8 @@ abstract class AbstractImageTest extends ImagineTestCase
     public function testPaletteAssociatedIsRelatedToGivenColor($paletteClass, $input)
     {
         $palette = new $paletteClass();
+        /* @var \Imagine\Image\Palette\PaletteInterface $palette */
+        $palette->profile();
 
         $image = $this
             ->getImagine()


### PR DESCRIPTION
If a CMYK palette is reused (for instance because it's used in a Color instance cached in the `Palette\CMYK::$colors array`), the `testPaletteAssociatedIsRelatedToGivenColor` test may may because the reused palette instance may have a profile loaded, whereas the new palette instance may have a null profile.
So, let's always load the palette profile.