### PR TITLE
Typo fixed in GMagick\Imagine::create()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
   * Added jpeg_sampling_factors option when saving JPEG images (Gmagick/Imagick only) (@ausi)
   * Added BMP as supported image format (@mlocati)
   * Added support to new image type constants of Imagick (@ausi)
-  * Check that Imagick correctly supports profiles (@ausi) 
+  * Check that Imagick correctly supports profiles (@ausi)
+  * Fix creating Gmagick images with alpha colors when palette doesn't support alpha (@FractalizeR)
 
 ### 0.7.1 (2017-05-16)
   * Remove Symfony PHPUnit bridge as dependency (@craue)

--- a/lib/Imagine/Gmagick/Imagine.php
+++ b/lib/Imagine/Gmagick/Imagine.php
@@ -86,7 +86,7 @@ class Imagine extends AbstractImagine
                 $pixel   = new \GmagickPixel((string) $color);
             }
 
-            if ($color->getPalette()->supportsAlpha() && $color->getAlpha() < 100) {
+            if (!$color->getPalette()->supportsAlpha() && $color->getAlpha() !== null && $color->getAlpha() < 100) {
                 throw new NotSupportedException('alpha transparency is not supported');
             }
 


### PR DESCRIPTION
Supersedes #371