### PR TITLE
Implement customizable factory methods

### DIFF
--- a/lib/Imagine/Factory/AbstractClassFactory.php
+++ b/lib/Imagine/Factory/AbstractClassFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Imagine\Factory;
+
+use Imagine\Image\Metadata\ExifMetadataReader;
+use Imagine\Image\Metadata\DefaultMetadataReader;
+use Imagine\File\Loader;
+use Imagine\Image\Box;
+
+/**
+ * The default base implementation of Imagine\Factory\ClassFactoryInterface
+ */
+abstract class AbstractClassFactory implements ClassFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createMetadataReader()
+     */
+    public function createMetadataReader()
+    {
+        return $this->finalize(ExifMetadataReader::isSupported() ? new ExifMetadataReader() : new DefaultMetadataReader());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createBox()
+     */
+    public function createBox($width, $height)
+    {
+        return new Box($width, $height);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createFileLoader()
+     */
+    public function createFileLoader($path)
+    {
+        return $this->finalize(new Loader($path));
+    }
+
+    /**
+     * Finalize the newly created object.
+     *
+     * @param object $object
+     *
+     * @return object
+     */
+    protected function finalize($object)
+    {
+        if ($object instanceof ClassFactoryAwareInterface) {
+            $object->setClassFactory($this);
+        }
+
+        return $object;
+    }
+}

--- a/lib/Imagine/Factory/ClassFactoryAwareInterface.php
+++ b/lib/Imagine/Factory/ClassFactoryAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Imagine\Factory;
+
+/**
+ * An interface that classes that accepts a class factory should implement.
+ */
+interface ClassFactoryAwareInterface
+{
+    /**
+     * Set the class factory instance to be used.
+     *
+     * @param \Imagine\Factory\ClassFactoryInterface $classFactory
+     *
+     * @return $this
+     */
+    public function setClassFactory(ClassFactoryInterface $classFactory);
+
+    /**
+     * Get the class factory instance to be used.
+     *
+     * @return \Imagine\Factory\ClassFactoryInterface
+     */
+    public function getClassFactory();
+}

--- a/lib/Imagine/Factory/ClassFactoryInterface.php
+++ b/lib/Imagine/Factory/ClassFactoryInterface.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Imagine\Factory;
+
+use Imagine\Image\Palette\Color\ColorInterface;
+
+/**
+ * The interface that class factories must implement.
+ */
+interface ClassFactoryInterface
+{
+    /**
+     * Create a new instance of a metadata reader.
+     *
+     * @return \Imagine\Image\Metadata\MetadataReaderInterface
+     */
+    public function createMetadataReader();
+
+    /**
+     * Create new BoxInterface instance
+     *
+     * @param int $width The box width
+     * @param int $height The box height
+     *
+     * @return \Imagine\Image\BoxInterface
+     */
+    public function createBox($width, $height);
+
+    /**
+     * Create new FontInterface instance
+     *
+     * 
+     *
+     * @param string $file
+     * @param int $size the font size in points (e.g. 10pt means 10)
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
+     *
+     * @return \Imagine\Image\FontInterface
+     */
+    public function createFont($file, $size, ColorInterface $color);
+
+    /**
+     * Create a new instance of a file loader.
+     *
+     * @param string|mixed $path
+     *
+     * @return \Imagine\File\LoaderInterface
+     */
+    public function createFileLoader($path);
+
+    /**
+     * Crate a new instance of a layers interface
+     * @param \Imagine\Image\ImageInterface $image
+     * @return \Imagine\Image\LayersInterface
+     */
+    public function createLayers(\Imagine\Image\ImageInterface $image);
+
+    /**
+     * Create a new ImageInterface instance.
+     *
+     * @param mixed $resource
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
+     *
+     * @return \Imagine\Image\ImageInterface
+     */
+    public function createImage($resource, \Imagine\Image\Palette\PaletteInterface $palette, \Imagine\Image\Metadata\MetadataBag $metadata);
+    
+    /**
+     * Create a new DrawerInterface instance.
+     *
+     * @param mixed $resource
+     *
+     * @return \Imagine\Draw\DrawerInterface
+     */
+    public function createDrawer($resource);
+    
+    /**
+     * Create a new EffectsInterface instance.
+     *
+     * @param mixed $resource
+     *
+     * @return \Imagine\Effects\EffectsInterface
+     */
+    public function createEffects($resource);    
+}

--- a/lib/Imagine/Gd/ClassFactory.php
+++ b/lib/Imagine/Gd/ClassFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Imagine\Gd;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Factory\AbstractClassFactory;
+use Imagine\Exception\RuntimeException;
+
+/**
+* The final implementation of Imagine\Factory\ClassFactoryInterface for GD.
+ */
+class ClassFactory extends AbstractClassFactory
+{
+    /**
+     * @var array|null
+     */
+    private static $gdInfo;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createFont()
+     */
+    public function createFont($file, $size, ColorInterface $color)
+    {
+        $gdInfo = static::getGDInfo();
+        if (!$gdInfo['FreeType Support']) {
+            throw new RuntimeException('GD is not compiled with FreeType support');
+        }
+
+        return $this->finalize(new Font($file, $size, $color));
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createLayers()
+     */
+    public function createLayers(ImageInterface $image)
+    {
+        return $this->finalize(new Layers($image, $image->palette(), $image->getGdResource()));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createImage()
+     */
+    public function createImage($resource, \Imagine\Image\Palette\PaletteInterface $palette, \Imagine\Image\Metadata\MetadataBag $metadata)
+    {
+        return $this->finalize(new Image($resource, $palette, $metadata));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createDrawer()
+     */
+    public function createDrawer($resource)
+    {
+        return $this->finalize(new Drawer($resource));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createEffects()
+     */
+    public function createEffects($resource)
+    {
+        return $this->finalize(new Effects($resource));
+    }
+
+    /**
+     * @return array
+     */
+    protected static function getGDInfo()
+    {
+        if (self::$gdInfo === null) {
+            if (!function_exists('gd_info')) {
+                throw new RuntimeException('Gd not installed');
+            }
+            self::$gdInfo = gd_info();
+        }
+
+        return self::$gdInfo;
+    }
+}

--- a/lib/Imagine/Gd/Font.php
+++ b/lib/Imagine/Gd/Font.php
@@ -13,7 +13,6 @@ namespace Imagine\Gd;
 
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\AbstractFont;
-use Imagine\Image\Box;
 
 /**
  * Font implementation using the GD library
@@ -44,6 +43,16 @@ final class Font extends AbstractFont
         $width    = abs(max($xs) - min($xs));
         $height   = abs(max($ys) - min($ys));
 
-        return new Box($width, $height);
+        return $this->getClassFactory()->createBox($width, $height);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractFont::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Gd/Image.php
+++ b/lib/Imagine/Gd/Image.php
@@ -13,7 +13,6 @@ namespace Imagine\Gd;
 
 use Imagine\Image\AbstractImage;
 use Imagine\Image\ImageInterface;
-use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Metadata\MetadataBag;
 use Imagine\Image\Palette\Color\ColorInterface;
@@ -98,7 +97,7 @@ final class Image extends AbstractImage
             throw new RuntimeException('Image copy operation failed');
         }
 
-        return new Image($copy, $this->palette, $this->metadata);
+        return $this->getClassFactory()->createImage($copy, $this->palette, $this->metadata);
     }
 
     /**
@@ -344,7 +343,7 @@ final class Image extends AbstractImage
      */
     public function draw()
     {
-        return new Drawer($this->resource);
+        return $this->getClassFactory()->createDrawer($this->resource);
     }
 
     /**
@@ -352,7 +351,7 @@ final class Image extends AbstractImage
      */
     public function effects()
     {
-        return new Effects($this->resource);
+        return $this->getClassFactory()->createEffects($this->resource);
     }
 
     /**
@@ -360,7 +359,7 @@ final class Image extends AbstractImage
      */
     public function getSize()
     {
-        return new Box(imagesx($this->resource), imagesy($this->resource));
+        return $this->getClassFactory()->createBox(imagesx($this->resource), imagesy($this->resource));
     }
 
     /**
@@ -469,7 +468,7 @@ final class Image extends AbstractImage
     public function layers()
     {
         if (null === $this->layers) {
-            $this->layers = new Layers($this, $this->palette, $this->resource);
+            $this->layers = $this->getClassFactory()->createLayers($this);
         }
 
         return $this->layers;
@@ -787,5 +786,15 @@ final class Image extends AbstractImage
         }
 
         return $supportedFormats;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractImage::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Gd/Layers.php
+++ b/lib/Imagine/Gd/Layers.php
@@ -63,7 +63,7 @@ class Layers extends AbstractLayers
      */
     public function current()
     {
-        return new Image($this->resource, $this->palette, new MetadataBag());
+        return $this->getClassFactory()->createImage($this->resource, $this->palette, new MetadataBag());
     }
 
     /**
@@ -120,7 +120,7 @@ class Layers extends AbstractLayers
     public function offsetGet($offset)
     {
         if (0 === $offset) {
-            return new Image($this->resource, $this->palette, new MetadataBag());
+            return $this->getClassFactory()->createImage($this->resource, $this->palette, new MetadataBag());
         }
 
         throw new RuntimeException('GD only supports one layer at offset 0');
@@ -140,5 +140,15 @@ class Layers extends AbstractLayers
     public function offsetUnset($offset)
     {
         throw new NotSupportedException('GD does not support layer unset');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractLayers::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Gmagick/ClassFactory.php
+++ b/lib/Imagine/Gmagick/ClassFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Imagine\Gmagick;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Factory\AbstractClassFactory;
+
+/**
+* The final implementation of Imagine\Factory\ClassFactoryInterface for Gmagick.
+ */
+class ClassFactory extends AbstractClassFactory
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createFont()
+     */
+    public function createFont($file, $size, ColorInterface $color)
+    {
+        $gmagick = new \Gmagick();
+        $gmagick->newimage(1, 1, 'transparent');
+        
+        return $this->finalize(new Font($gmagick, $file, $size, $color));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createLayers()
+     */
+    public function createLayers(ImageInterface $image)
+    {
+        return $this->finalize(new Layers($image, $image->palette(), $image->getGmagick()));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createImage()
+     */
+    public function createImage($resource, \Imagine\Image\Palette\PaletteInterface $palette, \Imagine\Image\Metadata\MetadataBag $metadata)
+    {
+        return $this->finalize(new Image($resource, $palette, $metadata));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createDrawer()
+     */
+    public function createDrawer($resource)
+    {
+        return $this->finalize(new Drawer($resource));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createEffects()
+     */
+    public function createEffects($resource)
+    {
+        return $this->finalize(new Effects($resource));
+    }
+}

--- a/lib/Imagine/Gmagick/Font.php
+++ b/lib/Imagine/Gmagick/Font.php
@@ -12,7 +12,6 @@
 namespace Imagine\Gmagick;
 
 use Imagine\Image\AbstractFont;
-use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
 
 /**
@@ -56,8 +55,18 @@ final class Font extends AbstractFont
 
         $info = $this->gmagick->queryfontmetrics($text, $string);
 
-        $box = new Box($info['textWidth'], $info['textHeight']);
+        $box = $this->getClassFactory()->createBox($info['textWidth'], $info['textHeight']);
 
         return $box;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractFont::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Gmagick/Layers.php
+++ b/lib/Imagine/Gmagick/Layers.php
@@ -131,7 +131,7 @@ class Layers extends AbstractLayers
         if (!isset($this->layers[$offset])) {
             try {
                 $this->resource->setimageindex($offset);
-                $this->layers[$offset] = new Image($this->resource->getimage(), $this->palette, new MetadataBag());
+                $this->layers[$offset] = $this->getClassFactory()->createImage($this->resource->getimage(), $this->palette, new MetadataBag());
             } catch (\GmagickException $e) {
                 throw new RuntimeException(sprintf('Failed to extract layer %d', $offset), $e->getCode(), $e);
             }
@@ -268,5 +268,15 @@ class Layers extends AbstractLayers
         } catch (\GmagickException $e) {
             throw new RuntimeException('Unable to remove layer', $e->getCode(), $e);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractLayers::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Image/AbstractFont.php
+++ b/lib/Imagine/Image/AbstractFont.php
@@ -12,12 +12,19 @@
 namespace Imagine\Image;
 
 use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Factory\ClassFactoryAwareInterface;
+use Imagine\Factory\ClassFactoryInterface;
 
 /**
  * Abstract font base class
  */
-abstract class AbstractFont implements FontInterface
+abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
 {
+    /**
+     * @var \Imagine\Factory\ClassFactoryInterface|null
+     */
+    private $classFactory;
+
     /**
      * @var string
      */
@@ -72,4 +79,37 @@ abstract class AbstractFont implements FontInterface
     {
         return $this->color;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::getClassFactory()
+     */
+    public function getClassFactory()
+    {
+        if ($this->classFactory === null) {
+            $this->classFactory = $this->createDefaultClassFactory();
+        }
+        
+        return $this->classFactory;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::setClassFactory()
+     */
+    public function setClassFactory(ClassFactoryInterface $classFactory)
+    {
+        $this->classFactory = $classFactory;
+        
+        return $this;
+    }
+    
+    /**
+     * Create an instance of the default class factory.
+     *
+     * @return \Imagine\Factory\ClassFactoryInterface
+     */
+    protected abstract function createDefaultClassFactory();
 }

--- a/lib/Imagine/Image/AbstractImage.php
+++ b/lib/Imagine/Image/AbstractImage.php
@@ -13,13 +13,20 @@ namespace Imagine\Image;
 
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Image\Metadata\MetadataBag;
+use Imagine\Factory\ClassFactoryInterface;
+use Imagine\Factory\ClassFactoryAwareInterface;
 
-abstract class AbstractImage implements ImageInterface
+abstract class AbstractImage implements ImageInterface, ClassFactoryAwareInterface
 {
     /**
      * @var MetadataBag
      */
     protected $metadata;
+
+    /**
+     * @var \Imagine\Factory\ClassFactoryInterface|null
+     */
+    private $classFactory;
 
     /**
      * {@inheritdoc}
@@ -117,4 +124,36 @@ abstract class AbstractImage implements ImageInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::getClassFactory()
+     */
+    public function getClassFactory()
+    {
+        if ($this->classFactory === null) {
+            $this->classFactory = $this->createDefaultClassFactory();
+        }
+
+        return $this->classFactory;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::setClassFactory()
+     */
+    public function setClassFactory(ClassFactoryInterface $classFactory)
+    {
+        $this->classFactory = $classFactory;
+
+        return $this;
+    }
+
+    /**
+     * Create an instance of the default class factory.
+     *
+     * @return \Imagine\Factory\ClassFactoryInterface
+     */
+    protected abstract function createDefaultClassFactory();
 }

--- a/lib/Imagine/Image/AbstractImagine.php
+++ b/lib/Imagine/Image/AbstractImagine.php
@@ -11,15 +11,19 @@
 
 namespace Imagine\Image;
 
-use Imagine\Image\Metadata\DefaultMetadataReader;
-use Imagine\Image\Metadata\ExifMetadataReader;
 use Imagine\Image\Metadata\MetadataReaderInterface;
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Factory\ClassFactoryInterface;
 
 abstract class AbstractImagine implements ImagineInterface
 {
     /** @var MetadataReaderInterface */
     private $metadataReader;
+
+    /**
+     * @var \Imagine\Factory\ClassFactoryInterface|null
+     */
+    private $classFactory;
 
     /**
      * @param MetadataReaderInterface $metadataReader
@@ -39,15 +43,44 @@ abstract class AbstractImagine implements ImagineInterface
     public function getMetadataReader()
     {
         if (null === $this->metadataReader) {
-            if (ExifMetadataReader::isSupported()) {
-                $this->metadataReader = new ExifMetadataReader();
-            } else {
-                $this->metadataReader = new DefaultMetadataReader();
-            }
+            $this->metadataReader = $this->getClassFactory()->createMetadataReader();
         }
 
         return $this->metadataReader;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::setClassFactory()
+     */
+    public function setClassFactory(ClassFactoryInterface $classFactory)
+    {
+        $this->classFactory = $classFactory;
+
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::getClassFactory()
+     */
+    public function getClassFactory()
+    {
+        if ($this->classFactory === null) {
+            $this->classFactory = $this->createDefaultClassFactory();
+        }
+
+        return $this->classFactory;
+    }
+
+    /**
+     * Create an instance of the default class factory.
+     *
+     * @return \Imagine\Factory\ClassFactoryInterface
+     */
+    protected abstract function createDefaultClassFactory();
 
     /**
      * Checks a path that could be used with ImagineInterface::open and returns

--- a/lib/Imagine/Image/AbstractLayers.php
+++ b/lib/Imagine/Image/AbstractLayers.php
@@ -11,8 +11,16 @@
 
 namespace Imagine\Image;
 
-abstract class AbstractLayers implements LayersInterface
+use Imagine\Factory\ClassFactoryAwareInterface;
+use Imagine\Factory\ClassFactoryInterface;
+
+abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInterface
 {
+    /**
+     * @var \Imagine\Factory\ClassFactoryInterface|null
+     */
+    private $classFactory;
+
     /**
      * {@inheritdoc}
      */
@@ -58,4 +66,37 @@ abstract class AbstractLayers implements LayersInterface
     {
         return isset($this[$offset]);
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::setClassFactory()
+     */
+    public function setClassFactory(ClassFactoryInterface $classFactory)
+    {
+        $this->classFactory = $classFactory;
+
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryAwareInterface::getClassFactory()
+     */
+    public function getClassFactory()
+    {
+        if ($this->classFactory === null) {
+            $this->classFactory = $this->createDefaultClassFactory();
+        }
+
+        return $this->classFactory;
+    }
+
+    /**
+     * Create an instance of the default class factory.
+     *
+     * @return \Imagine\Factory\ClassFactoryInterface
+     */
+    protected abstract function createDefaultClassFactory();
 }

--- a/lib/Imagine/Image/ImagineInterface.php
+++ b/lib/Imagine/Image/ImagineInterface.php
@@ -14,11 +14,12 @@ namespace Imagine\Image;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
+use Imagine\Factory\ClassFactoryAwareInterface;
 
 /**
  * The imagine interface
  */
-interface ImagineInterface
+interface ImagineInterface extends ClassFactoryAwareInterface
 {
     const VERSION = '0.7-dev';
 

--- a/lib/Imagine/Imagick/ClassFactory.php
+++ b/lib/Imagine/Imagick/ClassFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Imagine\Imagick;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Factory\AbstractClassFactory;
+use Imagine\Image\Palette\Color\ColorInterface;
+
+/**
+ * The final implementation of Imagine\Factory\ClassFactoryInterface for Imagick.
+ */
+class ClassFactory extends AbstractClassFactory
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createFont()
+     */
+    public function createFont($file, $size, ColorInterface $color)
+    {
+        return $this->finalize(new Font(new \Imagick(), $file, $size, $color));
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createLayers()
+     */
+    public function createLayers(ImageInterface $image)
+    {
+        return $this->finalize(new Layers($image, $image->palette(), $image->getImagick()));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createImage()
+     */
+    public function createImage($resource, \Imagine\Image\Palette\PaletteInterface $palette, \Imagine\Image\Metadata\MetadataBag $metadata)
+    {
+        return $this->finalize(new Image($resource, $palette, $metadata));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createDrawer()
+     */
+    public function createDrawer($resource)
+    {
+        return $this->finalize(new Drawer($resource));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Factory\ClassFactoryInterface::createEffects()
+     */
+    public function createEffects($resource)
+    {
+        return $this->finalize(new \Imagine\Imagick\Effects($resource));
+    }
+}

--- a/lib/Imagine/Imagick/Font.php
+++ b/lib/Imagine/Imagick/Font.php
@@ -12,7 +12,6 @@
 namespace Imagine\Imagick;
 
 use Imagine\Image\AbstractFont;
-use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
 
 /**
@@ -61,8 +60,18 @@ final class Font extends AbstractFont
 
         $info = $this->imagick->queryFontMetrics($text, $string);
 
-        $box = new Box($info['textWidth'], $info['textHeight']);
+        $box = $this->getClassFactory()->createBox($info['textWidth'], $info['textHeight']);
 
         return $box;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractFont::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Imagick/Imagine.php
+++ b/lib/Imagine/Imagick/Imagine.php
@@ -22,7 +22,6 @@ use Imagine\Image\Palette\CMYK;
 use Imagine\Image\Palette\RGB;
 use Imagine\Image\Palette\Grayscale;
 use Imagine\File\LoaderInterface;
-use Imagine\File\Loader;
 
 /**
  * Imagine implementation using the Imagick PHP extension
@@ -50,7 +49,7 @@ final class Imagine extends AbstractImagine
      */
     public function open($path)
     {
-        $loader = $path instanceof LoaderInterface ? $path : new Loader($path);
+        $loader = $path instanceof LoaderInterface ? $path : $this->getClassFactory()->createFileLoader($path);
         $path = $loader->getPath();
 
         try {
@@ -66,7 +65,7 @@ final class Imagine extends AbstractImagine
                 $imagick = new \Imagick();
                 $imagick->readImageBlob($loader->getData());
             }
-            $image = new Image($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readFile($loader));
+            $image = $this->getClassFactory()->createImage($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readFile($loader));
         } catch (\ImagickException $e) {
             throw new RuntimeException(sprintf('Unable to open image %s', $path), $e->getCode(), $e);
         }
@@ -106,7 +105,7 @@ final class Imagine extends AbstractImagine
             $pixel->clear();
             $pixel->destroy();
 
-            return new Image($imagick, $palette, new MetadataBag());
+            return $this->getClassFactory()->createImage($imagick, $palette, new MetadataBag());
         } catch (\ImagickException $e) {
             throw new RuntimeException('Could not create empty image', $e->getCode(), $e);
         }
@@ -123,7 +122,7 @@ final class Imagine extends AbstractImagine
             $imagick->readImageBlob($string);
             $imagick->setImageMatte(true);
 
-            return new Image($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readData($string));
+            return $this->getClassFactory()->createImage($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readData($string));
         } catch (\ImagickException $e) {
             throw new RuntimeException('Could not load image from string', $e->getCode(), $e);
         }
@@ -147,7 +146,7 @@ final class Imagine extends AbstractImagine
             throw new RuntimeException('Could not read image from resource', $e->getCode(), $e);
         }
 
-        return new Image($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readData($content, $resource));
+        return $this->getClassFactory()->createImage($imagick, $this->createPalette($imagick), $this->getMetadataReader()->readData($content, $resource));
     }
 
     /**
@@ -155,7 +154,7 @@ final class Imagine extends AbstractImagine
      */
     public function font($file, $size, ColorInterface $color)
     {
-        return new Font(new \Imagick(), $file, $size, $color);
+        return $this->getClassFactory()->createFont($file, $size, $color);
     }
 
     /**
@@ -195,5 +194,15 @@ final class Imagine extends AbstractImagine
         list($version) = sscanf($v['versionString'], 'ImageMagick %s %04d-%02d-%02d %s %s');
 
         return $version;
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractImagine::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/lib/Imagine/Imagick/Layers.php
+++ b/lib/Imagine/Imagick/Layers.php
@@ -113,7 +113,7 @@ class Layers extends AbstractLayers
         for ($offset = 0; $offset < $count; $offset++) {
             try {
                 $coalescedResource->setIteratorIndex($offset);
-                $this->layers[$offset] = new Image($coalescedResource->getImage(), $this->palette, new MetadataBag());
+                $this->layers[$offset] = $this->getClassFactory()->createImage($coalescedResource->getImage(), $this->palette, new MetadataBag());
             } catch (\ImagickException $e) {
                 throw new RuntimeException('Failed to retrieve layer', $e->getCode(), $e);
             }
@@ -141,7 +141,7 @@ class Layers extends AbstractLayers
         if (!isset($this->layers[$offset])) {
             try {
                 $this->resource->setIteratorIndex($offset);
-                $this->layers[$offset] = new Image($this->resource->getImage(), $this->palette, new MetadataBag());
+                $this->layers[$offset] = $this->getClassFactory()->createImage($this->resource->getImage(), $this->palette, new MetadataBag());
             } catch (\ImagickException $e) {
                 throw new RuntimeException(sprintf('Failed to extract layer %d', $offset), $e->getCode(), $e);
             }
@@ -267,5 +267,15 @@ class Layers extends AbstractLayers
         } catch (\ImagickException $e) {
             throw new RuntimeException('Unable to remove layer', $e->getCode(), $e);
         }
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractLayers::createDefaultClassFactory()
+     */
+    protected function createDefaultClassFactory()
+    {
+        return new ClassFactory();
     }
 }

--- a/tests/Imagine/Test/Factory/AbstractClassFactoryTest.php
+++ b/tests/Imagine/Test/Factory/AbstractClassFactoryTest.php
@@ -23,12 +23,22 @@ abstract class AbstractClassFactoryTest extends ImagineTestCase
         $image = $imagine->create(new Box(1, 1));
         $this->assertSame($imagine->getClassFactory(), $image->getClassFactory());
         $palette = new RGB();
-        $font = $imagine->font(__FILE__, 1, $palette->color('#000000'));
-        $this->assertSame($imagine->getClassFactory(), $font->getClassFactory());
+        if ($this->canTestFont()) {
+            $font = $imagine->font(__FILE__, 1, $palette->color('#000000'));
+            $this->assertSame($imagine->getClassFactory(), $font->getClassFactory());
+        }
     }
 
     /**
      * @return \Imagine\Image\ImagineInterface
      */
     protected abstract function getImagine();
+
+    /**
+     * @return bool
+     */
+    protected function canTestFont()
+    {
+        return true;
+    }
 }

--- a/tests/Imagine/Test/Factory/AbstractClassFactoryTest.php
+++ b/tests/Imagine/Test/Factory/AbstractClassFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Test\Factory;
+
+use Imagine\Image\Box;
+use Imagine\Test\ImagineTestCase;
+use Imagine\Image\Palette\RGB;
+
+abstract class AbstractClassFactoryTest extends ImagineTestCase
+{
+    public function testClassFactoryIsForwarded()
+    {
+        $imagine = $this->getImagine();
+        $image = $imagine->create(new Box(1, 1));
+        $this->assertSame($imagine->getClassFactory(), $image->getClassFactory());
+        $palette = new RGB();
+        $font = $imagine->font(__FILE__, 1, $palette->color('#000000'));
+        $this->assertSame($imagine->getClassFactory(), $font->getClassFactory());
+    }
+
+    /**
+     * @return \Imagine\Image\ImagineInterface
+     */
+    protected abstract function getImagine();
+}

--- a/tests/Imagine/Test/Gd/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Gd/ClassFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Test\Gd;
+
+use Imagine\Gd\Imagine;
+use Imagine\Test\Factory\AbstractClassFactoryTest;
+
+/**
+ * @group ext-gd
+ */
+class ClassFactoryTest extends AbstractClassFactoryTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        if (!function_exists('gd_info')) {
+            $this->markTestSkipped('Gd not installed');
+        }
+    }
+    
+    protected function getImagine()
+    {
+        return new Imagine();
+    }
+}

--- a/tests/Imagine/Test/Gd/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Gd/ClassFactoryTest.php
@@ -27,9 +27,20 @@ class ClassFactoryTest extends AbstractClassFactoryTest
             $this->markTestSkipped('Gd not installed');
         }
     }
-    
+
     protected function getImagine()
     {
         return new Imagine();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @see \Imagine\Test\Factory\AbstractClassFactoryTest::canTestFont()
+     */
+    protected function canTestFont()
+    {
+        $info = gd_info();
+
+        return (bool) $info['FreeType Support'];
     }
 }

--- a/tests/Imagine/Test/Gmagick/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Gmagick/ClassFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Test\Gmagick;
+
+use Imagine\Gmagick\Imagine;
+use Imagine\Test\Factory\AbstractClassFactoryTest;
+
+/**
+ * @group ext-gd
+ */
+class ClassFactoryTest extends AbstractClassFactoryTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        if (!class_exists('Gmagick')) {
+            $this->markTestSkipped('Gmagick is not installed');
+        }
+    }
+    
+    protected function getImagine()
+    {
+        return new Imagine();
+    }
+}

--- a/tests/Imagine/Test/Imagick/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Imagick/ClassFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Test\Imagick;
+
+use Imagine\Imagick\Imagine;
+use Imagine\Test\Factory\AbstractClassFactoryTest;
+
+/**
+ * @group ext-gd
+ */
+class ClassFactoryTest extends AbstractClassFactoryTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        if (!class_exists('Imagick')) {
+            $this->markTestSkipped('Imagick is not installed');
+        }
+    }
+    
+    protected function getImagine()
+    {
+        return new Imagine();
+    }
+}


### PR DESCRIPTION
What about introducing a FactoryClassInterface class that developers can implement in order to override the default classes created?

Currently, the classes that can be implemented are:
- Imagine\Image\Metadata\MetadataReaderInterface
- Imagine\Image\BoxInterface
- Imagine\Image\FontInterface
- Imagine\File\LoaderInterface
- Imagine\Image\LayersInterface
- Imagine\Image\ImageInterface

Supersedes #212 and #279