### PR TITLE
Add opacity parameter to paste methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   * Fix copy methods of Images (the original image and its new copy are now fully detached) (@mlocati)
   * It's now possible to use `clone $image` as an alternative to `$image->copy()` (@mlocati)
   * Add support to custom classes for BoxInterface, MetadataReaderInterface, FontInterface, LoaderInterface, LayersInterface, ImageInterface (@mlocati)
+  * Add support for pasting with alpha for GD and Imagick (@AlloVince, @mlocati)
 
 ### 0.7.1 (2017-05-16)
   * Remove Symfony PHPUnit bridge as dependency (@craue)

--- a/lib/Imagine/Filter/Basic/Paste.php
+++ b/lib/Imagine/Filter/Basic/Paste.php
@@ -11,6 +11,7 @@
 
 namespace Imagine\Filter\Basic;
 
+use Imagine\Exception\InvalidArgumentException;
 use Imagine\Filter\FilterInterface;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\PointInterface;
@@ -31,16 +32,29 @@ class Paste implements FilterInterface
     private $start;
 
     /**
+     * How to paste the image, from 0 (fully transparent) to 100 (fully opaque).
+     *
+     * @var int
+     */
+    private $alpha;
+
+    /**
      * Constructs a Paste filter with given ImageInterface to paste and x, y
      * coordinates of target position.
      *
      * @param ImageInterface $image
      * @param PointInterface $start
+     * @param int $alpha how to paste the image, from 0 (fully transparent) to 100 (fully opaque)
      */
-    public function __construct(ImageInterface $image, PointInterface $start)
+    public function __construct(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
         $this->image = $image;
         $this->start = $start;
+        $alpha = (int) round($alpha);
+        if ($alpha < 0 || $alpha > 100) {
+            throw new InvalidArgumentException(sprintf('The %1$s argument can range from %2$d to %3$d, but you specified %4$d.', '$alpha', 0, 100, $alpha));
+        }
+        $this->alpha = $alpha;
     }
 
     /**
@@ -48,6 +62,6 @@ class Paste implements FilterInterface
      */
     public function apply(ImageInterface $image)
     {
-        return $image->paste($this->image, $this->start);
+        return $image->paste($this->image, $this->start, $this->alpha);
     }
 }

--- a/lib/Imagine/Filter/Transformation.php
+++ b/lib/Imagine/Filter/Transformation.php
@@ -162,9 +162,9 @@ final class Transformation implements FilterInterface, ManipulatorInterface
     /**
      * {@inheritdoc}
      */
-    public function paste(ImageInterface $image, PointInterface $start)
+    public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
-        return $this->add(new Paste($image, $start));
+        return $this->add(new Paste($image, $start, $alpha));
     }
 
     /**

--- a/lib/Imagine/Gd/Imagine.php
+++ b/lib/Imagine/Gd/Imagine.php
@@ -67,7 +67,7 @@ final class Imagine extends AbstractImagine
             throw new RuntimeException('Could not set background color fill');
         }
 
-        if ($color->getAlpha() >= 95) {
+        if ($color->getAlpha() <= 5) {
             imagecolortransparent($resource, $index);
         }
 

--- a/lib/Imagine/Gmagick/Image.php
+++ b/lib/Imagine/Gmagick/Image.php
@@ -12,6 +12,7 @@
 namespace Imagine\Gmagick;
 
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Factory\ClassFactoryInterface;
@@ -185,20 +186,29 @@ final class Image extends AbstractImage
      *
      * @return ImageInterface
      */
-    public function paste(ImageInterface $image, PointInterface $start)
+    public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
         if (!$image instanceof self) {
             throw new InvalidArgumentException(sprintf('Gmagick\Image can only paste() Gmagick\Image instances, %s given', get_class($image)));
+        }
+
+        $alpha = (int) round($alpha);
+        if ($alpha < 0 || $alpha > 100) {
+            throw new InvalidArgumentException(sprintf('The %1$s argument can range from %2$d to %3$d, but you specified %4$d.', '$alpha', 0, 100, $alpha));
         }
 
         if (!$this->getSize()->contains($image->getSize(), $start)) {
             throw new OutOfBoundsException('Cannot paste image of the given size at the specified position, as it moves outside of the current image\'s box');
         }
 
-        try {
-            $this->gmagick->compositeimage($image->gmagick, \Gmagick::COMPOSITE_DEFAULT, $start->getX(), $start->getY());
-        } catch (\GmagickException $e) {
-            throw new RuntimeException('Paste operation failed', $e->getCode(), $e);
+        if ($alpha === 100) {
+            try {
+                $this->gmagick->compositeimage($image->gmagick, \Gmagick::COMPOSITE_DEFAULT, $start->getX(), $start->getY());
+            } catch (\GmagickException $e) {
+                throw new RuntimeException('Paste operation failed', $e->getCode(), $e);
+            }
+        } elseif ($alpha > 0) {
+            throw new NotSupportedException('Gmagick doesn\'t support paste with alpha.', 1);
         }
 
         return $this;

--- a/lib/Imagine/Image/ManipulatorInterface.php
+++ b/lib/Imagine/Image/ManipulatorInterface.php
@@ -83,6 +83,7 @@ interface ManipulatorInterface
      *
      * @param ImageInterface $image
      * @param PointInterface $start
+     * @param int $alpha How to paste the image, from 0 (fully transparent) to 100 (fully opaque)
      *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
@@ -90,7 +91,7 @@ interface ManipulatorInterface
      *
      * @return static
      */
-    public function paste(ImageInterface $image, PointInterface $start);
+    public function paste(ImageInterface $image, PointInterface $start, $alpha = 100);
 
     /**
      * Saves the image at a specified path, the target file extension is used

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -78,9 +78,9 @@ class ImageTest extends AbstractImageTest
     }
 
     /**
-     * {@inheritdoc}
+     * @dataProvider pasteWithAlphaProvider
      *
-     * @see \Imagine\Test\Image\AbstractImageTest::testPasteWithAlpha()
+     * @param int $alpha
      */
     public function testPasteWithAlpha($alpha)
     {

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -77,6 +77,19 @@ class ImageTest extends AbstractImageTest
         $this->markTestSkipped('Alpha transparency is not supported by Gmagick');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testPasteWithAlpha()
+     */
+    public function testPasteWithAlpha($alpha)
+    {
+        if ($alpha > 0 && $alpha < 100) {
+            $this->markTestSkipped('Alpha transparency is not supported by Gmagick');
+        }
+        parent::testPasteWithAlpha($alpha);
+    }
+
     protected function getImagine()
     {
         return new Imagine();

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -841,6 +841,35 @@ abstract class AbstractImageTest extends ImagineTestCase
         unlink(__DIR__ . '/tmp.jpg');
     }
 
+    public function pasteWithAlphaProvider()
+    {
+        return array(
+            array(0),
+            array(25),
+            array(50),
+            array(75),
+            array(100),
+        );
+    }
+
+    /**
+     * @dataProvider pasteWithAlphaProvider
+     *
+     * @param int $alpha
+     */
+    public function testPasteWithAlpha($alpha)
+    {
+        $rgb = new RGB();
+        $imagine = $this->getImagine();
+        $whiteImage = $imagine->create(new Box(3, 3), $rgb->color('FFF'));
+        $blackImage = $imagine->create(new Box(1, 1), $rgb->color('000'));
+        $whiteImage->paste($blackImage, new Point(1, 1), $alpha);
+        $finalColor = $whiteImage->getColorAt(new Point(1, 1));
+        $grayLevel = (int) (255 * (100 - $alpha) / 100);
+        $expectedColor = $rgb->color(array($grayLevel, $grayLevel, $grayLevel));
+        $this->assertEquals($expectedColor, $finalColor);
+    }
+
     abstract protected function getImageResolution(ImageInterface $image);
 
     private function getMonoLayeredImage()


### PR DESCRIPTION
This supersedes #215

Tests for GD will probably fail, because of a bug in `Imagine\Gd\Imagine::create()`: I'll update this PR once tests are done.