### PR TITLE
Let ExifMetadataReader::doReadData always return a MetadataBag

### DIFF
--- a/src/Image/Metadata/ExifMetadataReader.php
+++ b/src/Image/Metadata/ExifMetadataReader.php
@@ -73,7 +73,9 @@ class ExifMetadataReader extends AbstractMetadataReader
             $mime = 'image/jpeg';
         }
 
-        return $this->extract('data://' . $mime . ';base64,' . base64_encode($data));
+        $extracted = $this->extract('data://' . $mime . ';base64,' . base64_encode($data));
+
+        return is_array($extracted) ? new MetadataBag($extracted) : $extracted;
     }
 
     /**


### PR DESCRIPTION
ExifMetadataReader::extract can return an array or a MetadataBag instance.
In the phpdoc, we have that ExifMetadataReader::doReadData should return a MetadataBag instance: let's make it so.