### PR TITLE
Add __toString to ColorInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### NEXT (YYYY-MM-DD)
   * The `coalesce` method of `LayerInterface` instances now returns the LayerInterface itself (@mlocati)  
     **BREAKING CHANGE** if you have your own `LayerInterface` implementation, it now must return `$this`
+  * The `__toString` method has been added to `ColorInterface` since all its implementations have it (@mlocati)  
+    **BREAKING CHANGE** if you have your own `ColorInterface` implementation, it now must implement `__toString`
 
 ### 1.0.0-alpha1 (2018-08-28)
   * Imagine is now tested under Windows too (@mlocati)

--- a/src/Image/Palette/Color/CMYK.php
+++ b/src/Image/Palette/Color/CMYK.php
@@ -186,9 +186,9 @@ final class CMYK implements ColorInterface
     }
 
     /**
-     * Returns hex representation of the color.
+     * {@inheritdoc}
      *
-     * @return string
+     * @see \Imagine\Image\Palette\Color\ColorInterface::__toString()
      */
     public function __toString()
     {

--- a/src/Image/Palette/Color/ColorInterface.php
+++ b/src/Image/Palette/Color/ColorInterface.php
@@ -92,4 +92,11 @@ interface ColorInterface
      * @return bool
      */
     public function isOpaque();
+
+    /**
+     * Returns hex representation of the color.
+     *
+     * @return string
+     */
+    public function __toString();
 }

--- a/src/Image/Palette/Color/Gray.php
+++ b/src/Image/Palette/Color/Gray.php
@@ -120,9 +120,9 @@ final class Gray implements ColorInterface
     }
 
     /**
-     * Returns hex representation of the color.
+     * {@inheritdoc}
      *
-     * @return string
+     * @see \Imagine\Image\Palette\Color\ColorInterface::__toString()
      */
     public function __toString()
     {

--- a/src/Image/Palette/Color/RGB.php
+++ b/src/Image/Palette/Color/RGB.php
@@ -166,9 +166,9 @@ final class RGB implements ColorInterface
     }
 
     /**
-     * Returns hex representation of the color.
+     * {@inheritdoc}
      *
-     * @return string
+     * @see \Imagine\Image\Palette\Color\ColorInterface::__toString()
      */
     public function __toString()
     {


### PR DESCRIPTION
Every ColorInterface implementation already implements it, so by adding this we are sure it's available even in custom ColorInterface implementations.