### PR TITLE
Fix and normalize PHPDoc

### DIFF
--- a/src/Draw/DrawerInterface.php
+++ b/src/Draw/DrawerInterface.php
@@ -11,7 +11,6 @@
 
 namespace Imagine\Draw;
 
-use Imagine\Exception\RuntimeException;
 use Imagine\Image\AbstractFont;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Palette\Color\ColorInterface;
@@ -26,78 +25,77 @@ interface DrawerInterface
      * Draws an arc on a starting at a given x, y coordinates under a given
      * start and end angles.
      *
-     * @param PointInterface $center
-     * @param BoxInterface $size
+     * @param \Imagine\Image\PointInterface $center
+     * @param \Imagine\Image\BoxInterface $size
      * @param int $start
      * @param int $end
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param int $thickness
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1);
 
     /**
      * Same as arc, but also connects end points with a straight line.
      *
-     * @param PointInterface $center
-     * @param BoxInterface $size
+     * @param \Imagine\Image\PointInterface $center
+     * @param \Imagine\Image\BoxInterface $size
      * @param int $start
      * @param int $end
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param bool $fill
      * @param int $thickness
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1);
 
     /**
-     * Draws and ellipse with center at the given x, y coordinates, and given
-     * width and height.
+     * Draws and ellipse with center at the given x, y coordinates, and given width and height.
      *
-     * @param PointInterface $center
-     * @param BoxInterface $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\PointInterface $center
+     * @param \Imagine\Image\BoxInterface $size
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param bool $fill
      * @param int $thickness
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1);
 
     /**
      * Draws a line from start(x, y) to end(x, y) coordinates.
      *
-     * @param PointInterface $start
-     * @param PointInterface $end
-     * @param ColorInterface $outline
+     * @param \Imagine\Image\PointInterface $start
+     * @param \Imagine\Image\PointInterface $end
+     * @param \Imagine\Image\Palette\Color\ColorInterface $outline
      * @param int $thickness
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $outline, $thickness = 1);
 
     /**
      * Same as arc, but connects end points and the center.
      *
-     * @param PointInterface $center
-     * @param BoxInterface $size
+     * @param \Imagine\Image\PointInterface $center
+     * @param \Imagine\Image\BoxInterface $size
      * @param int $start
      * @param int $end
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param bool $fill
      * @param int $thickness
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1);
 
@@ -105,45 +103,43 @@ interface DrawerInterface
      * Places a one pixel point at specific coordinates and fills it with
      * specified color.
      *
-     * @param PointInterface $position
-     * @param ColorInterface $color
+     * @param \Imagine\Image\PointInterface $position
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function dot(PointInterface $position, ColorInterface $color);
 
     /**
-     * Draws a polygon using array of x, y coordinates. Must contain at least
-     * three coordinates.
+     * Draws a polygon using array of x, y coordinates. Must contain at least three coordinates.
      *
      * @param array $coordinates
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param bool $fill
      * @param int $thickness
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1);
 
     /**
-     * Annotates image with specified text at a given position starting on the
-     * top left of the final text box.
+     * Annotates image with specified text at a given position starting on the top left of the final text box.
      *
      * The rotation is done CW
      *
      * @param string $string
-     * @param AbstractFont $font
-     * @param PointInterface $position
+     * @param \Imagine\Image\AbstractFont $font
+     * @param \Imagine\Image\PointInterface $position
      * @param int $angle
      * @param int $width
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return DrawerInterface
+     * @return $this
      */
     public function text($string, AbstractFont $font, PointInterface $position, $angle = 0, $width = null);
 }

--- a/src/Effects/EffectsInterface.php
+++ b/src/Effects/EffectsInterface.php
@@ -11,7 +11,6 @@
 
 namespace Imagine\Effects;
 
-use Imagine\Exception\RuntimeException;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Utils\Matrix;
 
@@ -25,47 +24,47 @@ interface EffectsInterface
      *
      * @param float $correction
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function gamma($correction);
 
     /**
      * Invert the colors of the image.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function negative();
 
     /**
      * Grayscale the image.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function grayscale();
 
     /**
      * Colorize the image.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function colorize(ColorInterface $color);
 
     /**
      * Sharpens the image.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function sharpen();
 
@@ -74,9 +73,9 @@ interface EffectsInterface
      *
      * @param float|int $sigma
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function blur($sigma);
 
@@ -85,9 +84,9 @@ interface EffectsInterface
      *
      * @param int $brightness The level of brightness (-100 (black) to 100 (white))
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function brightness($brightness);
 
@@ -96,9 +95,9 @@ interface EffectsInterface
      *
      * @param \Imagine\Utils\Matrix $matrix The matrix from which derive the convolution kernel
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return EffectsInterface
+     * @return $this
      */
     public function convolve(Matrix $matrix);
 }

--- a/src/Factory/ClassFactoryInterface.php
+++ b/src/Factory/ClassFactoryInterface.php
@@ -15,12 +15,14 @@ interface ClassFactoryInterface
      * @var string
      */
     const HANDLE_GD = 'gd';
+
     /**
      * The handle to be used for the Gmagick manipulation library.
      *
      * @var string
      */
     const HANDLE_GMAGICK = 'gmagick';
+
     /**
      * The handle to be used for the Imagick manipulation library.
      *

--- a/src/File/Loader.php
+++ b/src/File/Loader.php
@@ -12,7 +12,7 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\RuntimeException;
 
 /**
- * Default implementation of the LoaderInterface.
+ * Default implementation of Imagine\File\LoaderInterface.
  */
 class Loader implements LoaderInterface
 {

--- a/src/Filter/Advanced/BlackWhite.php
+++ b/src/Filter/Advanced/BlackWhite.php
@@ -25,6 +25,9 @@ use Imagine\Image\Point;
  */
 class BlackWhite extends OnPixelBased implements FilterInterface
 {
+    /**
+     * @var \Imagine\Filter\Advanced\Grayscale
+     */
     protected $grayScaleFilter;
 
     /**
@@ -32,7 +35,7 @@ class BlackWhite extends OnPixelBased implements FilterInterface
      *
      * @param int $threshold the dask/light threshold, from 0 (all black) to 255 (all white)
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     public function __construct($threshold)
     {
@@ -43,10 +46,12 @@ class BlackWhite extends OnPixelBased implements FilterInterface
         $this->grayScaleFilter = new Grayscale();
 
         $rgb = new RGB();
-        parent::__construct(function (ImageInterface $image, Point $point) use ($threshold, $rgb) {
-            $newRedValue = $image->getColorAt($point)->getValue(ColorInterface::COLOR_RED) < $threshold ? 255 : 0;
-            $image->draw()->dot($point, $rgb->color(array($newRedValue, $newRedValue, $newRedValue)));
-        });
+        parent::__construct(
+            function (ImageInterface $image, Point $point) use ($threshold, $rgb) {
+                $newRedValue = $image->getColorAt($point)->getValue(ColorInterface::COLOR_RED) < $threshold ? 255 : 0;
+                $image->draw()->dot($point, $rgb->color(array($newRedValue, $newRedValue, $newRedValue)));
+            }
+        );
     }
 
     /**

--- a/src/Filter/Advanced/Border.php
+++ b/src/Filter/Advanced/Border.php
@@ -22,7 +22,7 @@ use Imagine\Image\Point;
 class Border implements FilterInterface
 {
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     private $color;
 
@@ -39,7 +39,7 @@ class Border implements FilterInterface
     /**
      * Constructs Border filter with given color, width and height.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      * @param int $width Width of the border on the left and right sides of the image
      * @param int $height Height of the border on the top and bottom sides of the image
      */
@@ -52,6 +52,8 @@ class Border implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Advanced/Canvas.php
+++ b/src/Filter/Advanced/Canvas.php
@@ -25,33 +25,32 @@ use Imagine\Image\PointInterface;
 class Canvas implements FilterInterface
 {
     /**
-     * @var BoxInterface
+     * @var \Imagine\Image\BoxInterface
      */
     private $size;
 
     /**
-     * @var PointInterface
+     * @var \Imagine\Image\PointInterface
      */
     private $placement;
 
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     private $background;
 
     /**
-     * @var ImagineInterface
+     * @var \Imagine\Image\ImagineInterface
      */
     private $imagine;
 
     /**
-     * Constructs Canvas filter with given width and height and the placement of the current image
-     * inside the new canvas.
+     * Constructs Canvas filter with given width and height and the placement of the current image inside the new canvas.
      *
-     * @param ImagineInterface $imagine
-     * @param BoxInterface $size
-     * @param PointInterface $placement
-     * @param ColorInterface $background
+     * @param \Imagine\Image\ImagineInterface $imagine
+     * @param \Imagine\Image\BoxInterface $size
+     * @param \Imagine\Image\PointInterface $placement
+     * @param \Imagine\Image\Palette\Color\ColorInterface $background
      */
     public function __construct(ImagineInterface $imagine, BoxInterface $size, PointInterface $placement = null, ColorInterface $background = null)
     {
@@ -63,6 +62,8 @@ class Canvas implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Advanced/Negation.php
+++ b/src/Filter/Advanced/Negation.php
@@ -20,11 +20,9 @@ use Imagine\Image\ImageInterface;
 class Negation implements FilterInterface
 {
     /**
-     * Applies scheduled transformation to ImageInterface instance.
+     * {@inheritdoc}
      *
-     * @param ImageInterface $image
-     *
-     * @return ImageInterface returns processed ImageInterface instance
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Advanced/Neighborhood.php
+++ b/src/Filter/Advanced/Neighborhood.php
@@ -37,21 +37,24 @@ use Imagine\Utils\Matrix;
 class Neighborhood implements FilterInterface
 {
     /**
-     * @var Matrix
+     * @var \Imagine\Utils\Matrix
      */
     protected $matrix;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param \Imagine\Utils\Matrix $matrix
+     */
     public function __construct(Matrix $matrix)
     {
         $this->matrix = $matrix;
     }
 
     /**
-     * Applies scheduled transformation to ImageInterface instance.
+     * {@inheritdoc}
      *
-     * @param ImageInterface $image
-     *
-     * @return ImageInterface returns processed ImageInterface instance
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Advanced/OnPixelBased.php
+++ b/src/Filter/Advanced/OnPixelBased.php
@@ -22,8 +22,18 @@ use Imagine\Image\Point;
  */
 class OnPixelBased implements FilterInterface
 {
+    /**
+     * @var callable
+     */
     protected $callback;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param callable $callback
+     *
+     * @throws \Imagine\Exception\InvalidArgumentException
+     */
     public function __construct($callback)
     {
         if (!is_callable($callback)) {
@@ -34,12 +44,9 @@ class OnPixelBased implements FilterInterface
     }
 
     /**
-     * Applies scheduled transformation to ImageInterface instance
-     * Returns processed ImageInterface instance.
+     * {@inheritdoc}
      *
-     * @param ImageInterface $image
-     *
-     * @return ImageInterface
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Advanced/RelativeResize.php
+++ b/src/Filter/Advanced/RelativeResize.php
@@ -16,12 +16,18 @@ use Imagine\Filter\FilterInterface;
 use Imagine\Image\ImageInterface;
 
 /**
- * The RelativeResize filter allows images to be resized relative to their
- * existing dimensions.
+ * The RelativeResize filter allows images to be resized relative to their existing dimensions.
  */
 class RelativeResize implements FilterInterface
 {
+    /**
+     * @var string
+     */
     private $method;
+
+    /**
+     * @var mixed
+     */
     private $parameter;
 
     /**
@@ -42,6 +48,8 @@ class RelativeResize implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/ApplyMask.php
+++ b/src/Filter/Basic/ApplyMask.php
@@ -20,12 +20,14 @@ use Imagine\Image\ImageInterface;
 class ApplyMask implements FilterInterface
 {
     /**
-     * @var ImageInterface
+     * @var \Imagine\Image\ImageInterface
      */
     private $mask;
 
     /**
-     * @param ImageInterface $mask
+     * Initialize the instance.
+     *
+     * @param \Imagine\Image\ImageInterface $mask
      */
     public function __construct(ImageInterface $mask)
     {
@@ -34,6 +36,8 @@ class ApplyMask implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Autorotate.php
+++ b/src/Filter/Basic/Autorotate.php
@@ -39,10 +39,13 @@ class Autorotate implements FilterInterface
      */
     const FLIP_HORIZONTALLY = 'H';
 
+    /**
+     * @var string|array|\Imagine\Image\Palette\Color\ColorInterface
+     */
     private $color;
 
     /**
-     * @param string|array|ColorInterface $color A color
+     * @param string|array|\Imagine\Image\Palette\Color\ColorInterface $color A color
      */
     public function __construct($color = '000000')
     {
@@ -51,6 +54,8 @@ class Autorotate implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {
@@ -70,7 +75,7 @@ class Autorotate implements FilterInterface
     /**
      * Get the transformations.
      *
-     * @param ImageInterface $image
+     * @param \Imagine\Image\ImageInterface $image
      *
      * @return array an array containing Autorotate::FLIP_VERTICALLY, Autorotate::FLIP_HORIZONTALLY, rotation degrees
      */
@@ -112,6 +117,11 @@ class Autorotate implements FilterInterface
         return $transformations;
     }
 
+    /**
+     * @param \Imagine\Image\ImageInterface $image
+     *
+     * @return \Imagine\Image\Palette\Color\ColorInterface
+     */
     private function getColor(ImageInterface $image)
     {
         if ($this->color instanceof ColorInterface) {

--- a/src/Filter/Basic/Copy.php
+++ b/src/Filter/Basic/Copy.php
@@ -21,6 +21,8 @@ class Copy implements FilterInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Crop.php
+++ b/src/Filter/Basic/Crop.php
@@ -22,21 +22,20 @@ use Imagine\Image\PointInterface;
 class Crop implements FilterInterface
 {
     /**
-     * @var PointInterface
+     * @var \Imagine\Image\PointInterface
      */
     private $start;
 
     /**
-     * @var BoxInterface
+     * @var \Imagine\Image\BoxInterface
      */
     private $size;
 
     /**
-     * Constructs a Crop filter with given x, y, coordinates and crop width and
-     * height values.
+     * Constructs a Crop filter with given x, y, coordinates and crop width and height values.
      *
-     * @param PointInterface $start
-     * @param BoxInterface $size
+     * @param \Imagine\Image\PointInterface $start
+     * @param \Imagine\Image\BoxInterface $size
      */
     public function __construct(PointInterface $start, BoxInterface $size)
     {
@@ -46,6 +45,8 @@ class Crop implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Fill.php
+++ b/src/Filter/Basic/Fill.php
@@ -21,12 +21,12 @@ use Imagine\Image\ImageInterface;
 class Fill implements FilterInterface
 {
     /**
-     * @var FillInterface
+     * @var \Imagine\Image\Fill\FillInterface
      */
     private $fill;
 
     /**
-     * @param FillInterface $fill
+     * @param \Imagine\Image\Fill\FillInterface $fill
      */
     public function __construct(FillInterface $fill)
     {
@@ -35,6 +35,8 @@ class Fill implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/FlipHorizontally.php
+++ b/src/Filter/Basic/FlipHorizontally.php
@@ -21,6 +21,8 @@ class FlipHorizontally implements FilterInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/FlipVertically.php
+++ b/src/Filter/Basic/FlipVertically.php
@@ -21,6 +21,8 @@ class FlipVertically implements FilterInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Paste.php
+++ b/src/Filter/Basic/Paste.php
@@ -22,12 +22,12 @@ use Imagine\Image\PointInterface;
 class Paste implements FilterInterface
 {
     /**
-     * @var ImageInterface
+     * @var \Imagine\Image\ImageInterface
      */
     private $image;
 
     /**
-     * @var PointInterface
+     * @var \Imagine\Image\PointInterface
      */
     private $start;
 
@@ -42,8 +42,8 @@ class Paste implements FilterInterface
      * Constructs a Paste filter with given ImageInterface to paste and x, y
      * coordinates of target position.
      *
-     * @param ImageInterface $image
-     * @param PointInterface $start
+     * @param \Imagine\Image\ImageInterface $image
+     * @param \Imagine\Image\PointInterface $start
      * @param int $alpha how to paste the image, from 0 (fully transparent) to 100 (fully opaque)
      */
     public function __construct(ImageInterface $image, PointInterface $start, $alpha = 100)
@@ -59,6 +59,8 @@ class Paste implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Resize.php
+++ b/src/Filter/Basic/Resize.php
@@ -21,15 +21,19 @@ use Imagine\Image\ImageInterface;
 class Resize implements FilterInterface
 {
     /**
-     * @var BoxInterface
+     * @var \Imagine\Image\BoxInterface
      */
     private $size;
+
+    /**
+     * @var string
+     */
     private $filter;
 
     /**
      * Constructs Resize filter with given width and height.
      *
-     * @param BoxInterface $size
+     * @param \Imagine\Image\BoxInterface $size
      * @param string $filter
      */
     public function __construct(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
@@ -40,6 +44,8 @@ class Resize implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Rotate.php
+++ b/src/Filter/Basic/Rotate.php
@@ -26,7 +26,7 @@ class Rotate implements FilterInterface
     private $angle;
 
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     private $background;
 
@@ -34,7 +34,7 @@ class Rotate implements FilterInterface
      * Constructs Rotate filter with given angle and background color.
      *
      * @param int $angle
-     * @param ColorInterface $background
+     * @param \Imagine\Image\Palette\Color\ColorInterface $background
      */
     public function __construct($angle, ColorInterface $background = null)
     {
@@ -44,6 +44,8 @@ class Rotate implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Save.php
+++ b/src/Filter/Basic/Save.php
@@ -43,6 +43,8 @@ class Save implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Show.php
+++ b/src/Filter/Basic/Show.php
@@ -43,6 +43,8 @@ class Show implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Strip.php
+++ b/src/Filter/Basic/Strip.php
@@ -21,6 +21,8 @@ class Strip implements FilterInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/Thumbnail.php
+++ b/src/Filter/Basic/Thumbnail.php
@@ -21,7 +21,7 @@ use Imagine\Image\ImageInterface;
 class Thumbnail implements FilterInterface
 {
     /**
-     * @var BoxInterface
+     * @var \Imagine\Image\BoxInterface
      */
     private $size;
 
@@ -38,7 +38,7 @@ class Thumbnail implements FilterInterface
     /**
      * Constructs the Thumbnail filter.
      *
-     * @param BoxInterface $size
+     * @param \Imagine\Image\BoxInterface $size
      * @param int|string $settings One or more of the ManipulatorInterface::THUMBNAIL_ flags (joined with |). It may be a string for backward compatibility with old constant values that were strings.
      * @param string $filter See ImageInterface::FILTER_... constants
      */
@@ -51,6 +51,8 @@ class Thumbnail implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/Basic/WebOptimization.php
+++ b/src/Filter/Basic/WebOptimization.php
@@ -20,10 +20,25 @@ use Imagine\Image\Palette\RGB;
  */
 class WebOptimization implements FilterInterface
 {
+    /**
+     * @var \Imagine\Image\Palette\RGB
+     */
     private $palette;
+
+    /**
+     * @var string|callable|null
+     */
     private $path;
+
+    /**
+     * @var array
+     */
     private $options;
 
+    /**
+     * @param string|callable|null $path
+     * @param array $options
+     */
     public function __construct($path = null, array $options = array())
     {
         $this->path = $path;
@@ -37,6 +52,8 @@ class WebOptimization implements FilterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -19,12 +19,11 @@ use Imagine\Image\ImageInterface;
 interface FilterInterface
 {
     /**
-     * Applies scheduled transformation to ImageInterface instance
-     * Returns processed ImageInterface instance.
+     * Applies scheduled transformation to an ImageInterface instance.
      *
-     * @param ImageInterface $image
+     * @param \Imagine\Image\ImageInterface $image
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface returns the processed ImageInterface instance
      */
     public function apply(ImageInterface $image);
 }

--- a/src/Filter/ImagineAware.php
+++ b/src/Filter/ImagineAware.php
@@ -22,14 +22,14 @@ abstract class ImagineAware implements FilterInterface
     /**
      * An ImagineInterface instance.
      *
-     * @var ImagineInterface
+     * @var \Imagine\Image\ImagineInterface
      */
     private $imagine;
 
     /**
      * Set ImagineInterface instance.
      *
-     * @param ImagineInterface $imagine An ImagineInterface instance
+     * @param \Imagine\Image\ImagineInterface $imagine An ImagineInterface instance
      */
     public function setImagine(ImagineInterface $imagine)
     {
@@ -39,9 +39,9 @@ abstract class ImagineAware implements FilterInterface
     /**
      * Get ImagineInterface instance.
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
-     * @return ImagineInterface
+     * @return \Imagine\Image\ImagineInterface
      */
     public function getImagine()
     {

--- a/src/Filter/Transformation.php
+++ b/src/Filter/Transformation.php
@@ -39,26 +39,26 @@ use Imagine\Image\PointInterface;
 final class Transformation implements FilterInterface, ManipulatorInterface
 {
     /**
-     * @var array
+     * @var array[\Imagine\Filter\FilterInterface[]]
      */
     private $filters = array();
 
     /**
-     * @var array
+     * @var array[\Imagine\Filter\FilterInterface[]]|null
      */
     private $sorted;
 
     /**
      * An ImagineInterface instance.
      *
-     * @var ImagineInterface
+     * @var \Imagine\Image\ImageInterface|null
      */
     private $imagine;
 
     /**
      * Class constructor.
      *
-     * @param ImagineInterface $imagine An ImagineInterface instance
+     * @param \Imagine\Image\ImageInterface|null $imagine An ImagineInterface instance
      */
     public function __construct(ImagineInterface $imagine = null)
     {
@@ -66,15 +66,14 @@ final class Transformation implements FilterInterface, ManipulatorInterface
     }
 
     /**
-     * Applies a given FilterInterface onto given ImageInterface and returns
-     * modified ImageInterface.
+     * Applies a given FilterInterface onto given ImageInterface and returns modified ImageInterface.
      *
-     * @param ImageInterface $image
-     * @param FilterInterface $filter
+     * @param \Imagine\Image\ImageInterface $image
+     * @param \Imagine\Filter\FilterInterface $filter
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function applyFilter(ImageInterface $image, FilterInterface $filter)
     {
@@ -109,6 +108,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Filter\FilterInterface::apply()
      */
     public function apply(ImageInterface $image)
     {
@@ -121,6 +122,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::copy()
      */
     public function copy()
     {
@@ -129,6 +132,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::crop()
      */
     public function crop(PointInterface $start, BoxInterface $size)
     {
@@ -137,6 +142,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::flipHorizontally()
      */
     public function flipHorizontally()
     {
@@ -145,6 +152,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::flipVertically()
      */
     public function flipVertically()
     {
@@ -153,6 +162,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::strip()
      */
     public function strip()
     {
@@ -161,6 +172,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::paste()
      */
     public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
@@ -169,6 +182,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::applyMask()
      */
     public function applyMask(ImageInterface $mask)
     {
@@ -177,6 +192,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::fill()
      */
     public function fill(FillInterface $fill)
     {
@@ -185,6 +202,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::resize()
      */
     public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -193,6 +212,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::rotate()
      */
     public function rotate($angle, ColorInterface $background = null)
     {
@@ -201,6 +222,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::save()
      */
     public function save($path = null, array $options = array())
     {
@@ -209,6 +232,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::show()
      */
     public function show($format, array $options = array())
     {
@@ -217,6 +242,8 @@ final class Transformation implements FilterInterface, ManipulatorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::thumbnail()
      */
     public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -224,13 +251,12 @@ final class Transformation implements FilterInterface, ManipulatorInterface
     }
 
     /**
-     * Registers a given FilterInterface in an internal array of filters for
-     * later application to an instance of ImageInterface.
+     * Registers a given FilterInterface in an internal array of filters for later application to an instance of ImageInterface.
      *
-     * @param FilterInterface $filter
+     * @param \Imagine\Filter\FilterInterface $filter
      * @param int $priority
      *
-     * @return Transformation
+     * @return $this
      */
     public function add(FilterInterface $filter, $priority = 0)
     {

--- a/src/Gd/Drawer.php
+++ b/src/Gd/Drawer.php
@@ -21,7 +21,7 @@ use Imagine\Image\Palette\Color\RGB as RGBColor;
 use Imagine\Image\PointInterface;
 
 /**
- * Drawer implementation using the GD library.
+ * Drawer implementation using the GD PHP extension.
  */
 final class Drawer implements DrawerInterface
 {
@@ -48,6 +48,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::arc()
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1)
     {
@@ -73,6 +75,8 @@ final class Drawer implements DrawerInterface
      * This function does not work properly because of a bug in GD.
      *
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::chord()
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -102,6 +106,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::ellipse()
      */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -131,6 +137,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::line()
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $color, $thickness = 1)
     {
@@ -154,6 +162,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::pieSlice()
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -183,6 +193,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::dot()
      */
     public function dot(PointInterface $position, ColorInterface $color)
     {
@@ -204,6 +216,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::polygon()
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -241,6 +255,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::text()
      */
     public function text($string, AbstractFont $font, PointInterface $position, $angle = 0, $width = null)
     {
@@ -282,14 +298,12 @@ final class Drawer implements DrawerInterface
     }
 
     /**
-     * Internal.
+     * Generates a GD color from Color instance.
      *
-     * Generates a GD color from Color instance
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @param ColorInterface $color
-     *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return resource
      */
@@ -317,12 +331,10 @@ final class Drawer implements DrawerInterface
     }
 
     /**
-     * Internal.
-     *
-     * Fits a string into box with given width
+     * Fits a string into box with given width.
      *
      * @param string $string
-     * @param AbstractFont $font
+     * @param \Imagine\Image\AbstractFont $font
      * @param int $angle
      * @param int $width
      */

--- a/src/Gd/Effects.php
+++ b/src/Gd/Effects.php
@@ -19,12 +19,20 @@ use Imagine\Image\Palette\Color\RGB as RGBColor;
 use Imagine\Utils\Matrix;
 
 /**
- * Effects implementation using the GD library.
+ * Effects implementation using the GD PHP extension.
  */
 class Effects implements EffectsInterface
 {
+    /**
+     * @var resource
+     */
     private $resource;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param resource $resource
+     */
     public function __construct($resource)
     {
         $this->resource = $resource;
@@ -32,6 +40,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::gamma()
      */
     public function gamma($correction)
     {
@@ -44,6 +54,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::negative()
      */
     public function negative()
     {
@@ -56,6 +68,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::grayscale()
      */
     public function grayscale()
     {
@@ -68,6 +82,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::colorize()
      */
     public function colorize(ColorInterface $color)
     {
@@ -84,6 +100,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::sharpen()
      */
     public function sharpen()
     {
@@ -99,6 +117,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::blur()
      */
     public function blur($sigma = 1)
     {
@@ -111,6 +131,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::brightness()
      */
     public function brightness($brightness)
     {
@@ -127,6 +149,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::convolve()
      */
     public function convolve(Matrix $matrix)
     {

--- a/src/Gd/Font.php
+++ b/src/Gd/Font.php
@@ -21,6 +21,8 @@ final class Font extends AbstractFont
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::box()
      */
     public function box($string, $angle = 0)
     {

--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -41,12 +41,12 @@ final class Image extends AbstractImage
     private $resource;
 
     /**
-     * @var Layers|null
+     * @var \Imagine\Gd\Layers|null
      */
     private $layers;
 
     /**
-     * @var PaletteInterface
+     * @var \Imagine\Image\Palette\PaletteInterface
      */
     private $palette;
 
@@ -54,8 +54,8 @@ final class Image extends AbstractImage
      * Constructs a new Image instance.
      *
      * @param resource $resource
-     * @param PaletteInterface $palette
-     * @param MetadataBag $metadata
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
      */
     public function __construct($resource, PaletteInterface $palette, MetadataBag $metadata)
     {
@@ -74,6 +74,11 @@ final class Image extends AbstractImage
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractImage::__clone()
+     */
     public function __clone()
     {
         parent::__clone();
@@ -103,7 +108,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::copy()
      */
     final public function copy()
     {
@@ -113,7 +118,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::crop()
      */
     final public function crop(PointInterface $start, BoxInterface $size)
     {
@@ -141,7 +146,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::paste()
      */
     final public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
@@ -183,7 +188,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::resize()
      */
     final public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -219,7 +224,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::rotate()
      */
     final public function rotate($angle, ColorInterface $background = null)
     {
@@ -239,7 +244,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::save()
      */
     final public function save($path = null, array $options = array())
     {
@@ -266,7 +271,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::show()
      */
     public function show($format, array $options = array())
     {
@@ -279,6 +284,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::get()
      */
     public function get($format, array $options = array())
     {
@@ -290,6 +297,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::__toString()
      */
     public function __toString()
     {
@@ -299,7 +308,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::flipHorizontally()
      */
     final public function flipHorizontally()
     {
@@ -329,7 +338,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::flipVertically()
      */
     final public function flipVertically()
     {
@@ -359,7 +368,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::strip()
      */
     final public function strip()
     {
@@ -369,6 +378,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::draw()
      */
     public function draw()
     {
@@ -377,6 +388,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::effects()
      */
     public function effects()
     {
@@ -385,6 +398,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getSize()
      */
     public function getSize()
     {
@@ -394,7 +409,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::applyMask()
      */
     public function applyMask(ImageInterface $mask)
     {
@@ -428,7 +443,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::fill()
      */
     public function fill(FillInterface $fill)
     {
@@ -447,6 +462,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::mask()
      */
     public function mask()
     {
@@ -461,6 +478,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::histogram()
      */
     public function histogram()
     {
@@ -478,6 +497,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getColorAt()
      */
     public function getColorAt(PointInterface $point)
     {
@@ -493,6 +514,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::layers()
      */
     public function layers()
     {
@@ -505,7 +528,9 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
-     **/
+     *
+     * @see \Imagine\Image\ImageInterface::interlace()
+     */
     public function interlace($scheme)
     {
         static $supportedInterlaceSchemes = array(
@@ -526,6 +551,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::palette()
      */
     public function palette()
     {
@@ -534,6 +561,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::profile()
      */
     public function profile(ProfileInterface $profile)
     {
@@ -542,6 +571,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::usePalette()
      */
     public function usePalette(PaletteInterface $palette)
     {
@@ -555,16 +586,14 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
-     * Performs save or show operation using one of GD's image... functions
+     * Performs save or show operation using one of GD's image... functions.
      *
      * @param string $format
      * @param array $options
      * @param string $filename
      *
-     * @throws InvalidArgumentException
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
      */
     private function saveOrOutput($format, array $options, $filename = null)
     {
@@ -645,14 +674,12 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
+     * Generates a GD image.
      *
-     * Generates a GD image
-     *
-     * @param BoxInterface $size
+     * @param \Imagine\Image\BoxInterface $size
      * @param string $operation the operation initiating the creation
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return resource
      */
@@ -680,14 +707,12 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
+     * Generates a GD color from Color instance.
      *
-     * Generates a GD color from Color instance
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @param ColorInterface $color
-     *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return int A color identifier
      */
@@ -707,9 +732,7 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
-     * Normalizes a given format name
+     * Normalizes a given format name.
      *
      * @param string $format
      *
@@ -727,9 +750,7 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
-     * Checks whether a given format is supported by GD library
+     * Checks whether a given format is supported by GD library.
      *
      * @param string $format
      *
@@ -746,6 +767,13 @@ final class Image extends AbstractImage
         return is_string($format) && isset($formats[$format]);
     }
 
+    /**
+     * @param callable $callback
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Exception
+     * @throws \Throwable
+     */
     private function withExceptionHandler($callback)
     {
         set_error_handler(function ($errno, $errstr, $errfile, $errline) {
@@ -770,13 +798,11 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
      * Get the mime type based on format.
      *
      * @param string $format
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return string mime-type
      */

--- a/src/Gd/Imagine.php
+++ b/src/Gd/Imagine.php
@@ -29,7 +29,7 @@ use Imagine\Image\Palette\RGB;
 final class Imagine extends AbstractImagine
 {
     /**
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      */
     public function __construct()
     {
@@ -38,6 +38,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::create()
      */
     public function create(BoxInterface $size, ColorInterface $color = null)
     {
@@ -76,6 +78,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::open()
      */
     public function open($path)
     {
@@ -93,6 +97,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::load()
      */
     public function load($string)
     {
@@ -101,6 +107,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::read()
      */
     public function read($resource)
     {
@@ -119,12 +127,23 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::font()
      */
     public function font($file, $size, ColorInterface $color)
     {
         return $this->getClassFactory()->createFont(ClassFactoryInterface::HANDLE_GD, $file, $size, $color);
     }
 
+    /**
+     * @param resource $resource
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     *
+     * @return \Imagine\Image\ImageInterface
+     */
     private function wrap($resource, PaletteInterface $palette, MetadataBag $metadata)
     {
         if (!imageistruecolor($resource)) {
@@ -161,6 +180,11 @@ final class Imagine extends AbstractImagine
         return $this->getClassFactory()->createImage(ClassFactoryInterface::HANDLE_GD, $resource, $palette, $metadata);
     }
 
+    /**
+     * @param string $version
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     */
     private function requireGdVersion($version)
     {
         if (!function_exists('gd_info')) {
@@ -171,6 +195,14 @@ final class Imagine extends AbstractImagine
         }
     }
 
+    /**
+     * @param string $string
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     *
+     * @return \Imagine\Image\ImageInterface
+     */
     private function doLoad($string, MetadataBag $metadata)
     {
         $resource = @imagecreatefromstring($string);

--- a/src/Gd/Layers.php
+++ b/src/Gd/Layers.php
@@ -20,11 +20,34 @@ use Imagine\Image\Palette\PaletteInterface;
 
 class Layers extends AbstractLayers
 {
+    /**
+     * @var \Imagine\Gd\Image
+     */
     private $image;
+
+    /**
+     * @var int
+     */
     private $offset;
+
+    /**
+     * @var resource
+     */
     private $resource;
+
+    /**
+     * @var \Imagine\Image\Palette\PaletteInterface
+     */
     private $palette;
 
+    /**
+     * @param \Imagine\Gd\Image $image
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param resource $resource
+     * @param int $initialOffset
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     */
     public function __construct(Image $image, PaletteInterface $palette, $resource, $initialOffset = 0)
     {
         if (!is_resource($resource)) {
@@ -39,6 +62,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::merge()
      */
     public function merge()
     {
@@ -46,6 +71,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::coalesce()
      */
     public function coalesce()
     {
@@ -54,6 +81,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::animate()
      */
     public function animate($format, $delay, $loops)
     {
@@ -62,6 +91,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::current()
      */
     public function current()
     {
@@ -70,6 +101,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::key()
      */
     public function key()
     {
@@ -78,6 +111,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::next()
      */
     public function next()
     {
@@ -86,6 +121,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
      */
     public function rewind()
     {
@@ -94,6 +131,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
      */
     public function valid()
     {
@@ -102,6 +141,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Countable::count()
      */
     public function count()
     {
@@ -110,6 +151,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetExists()
      */
     public function offsetExists($offset)
     {
@@ -118,6 +161,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetGet()
      */
     public function offsetGet($offset)
     {
@@ -130,6 +175,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetSet()
      */
     public function offsetSet($offset, $value)
     {
@@ -138,6 +185,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetUnset()
      */
     public function offsetUnset($offset)
     {

--- a/src/Gmagick/Drawer.php
+++ b/src/Gmagick/Drawer.php
@@ -41,6 +41,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::arc()
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1)
     {
@@ -79,6 +81,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::chord()
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -123,6 +127,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::ellipse()
      */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -164,6 +170,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::line()
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $color, $thickness = 1)
     {
@@ -195,6 +203,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::pieSlice()
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -229,6 +239,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::dot()
      */
     public function dot(PointInterface $position, ColorInterface $color)
     {
@@ -255,6 +267,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::polygon()
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -293,6 +307,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::text()
      */
     public function text($string, AbstractFont $font, PointInterface $position, $angle = 0, $width = null)
     {
@@ -339,9 +355,9 @@ final class Drawer implements DrawerInterface
     /**
      * Gets specifically formatted color string from Color instance.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @throws InvalidArgumentException In case a non-opaque color is passed
+     * @throws \Imagine\Exception\InvalidArgumentException In case a non-opaque color is passed
      *
      * @return \GmagickPixel
      */

--- a/src/Gmagick/Effects.php
+++ b/src/Gmagick/Effects.php
@@ -23,8 +23,16 @@ use Imagine\Utils\Matrix;
  */
 class Effects implements EffectsInterface
 {
+    /**
+     * @var \Gmagick
+     */
     private $gmagick;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param \Gmagick $gmagick
+     */
     public function __construct(\Gmagick $gmagick)
     {
         $this->gmagick = $gmagick;
@@ -32,6 +40,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::gamma()
      */
     public function gamma($correction)
     {
@@ -46,6 +56,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::negative()
      */
     public function negative()
     {
@@ -64,6 +76,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::grayscale()
      */
     public function grayscale()
     {
@@ -78,6 +92,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::colorize()
      */
     public function colorize(ColorInterface $color)
     {
@@ -86,6 +102,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::sharpen()
      */
     public function sharpen()
     {
@@ -94,6 +112,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::blur()
      */
     public function blur($sigma = 1)
     {
@@ -108,6 +128,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::brightness()
      */
     public function brightness($brightness)
     {
@@ -132,6 +154,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::convolve()
      */
     public function convolve(Matrix $matrix)
     {

--- a/src/Gmagick/Font.php
+++ b/src/Gmagick/Font.php
@@ -28,7 +28,7 @@ final class Font extends AbstractFont
      * @param \Gmagick $gmagick
      * @param string $file
      * @param int $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      */
     public function __construct(\Gmagick $gmagick, $file, $size, ColorInterface $color)
     {
@@ -39,6 +39,8 @@ final class Font extends AbstractFont
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::box()
      */
     public function box($string, $angle = 0)
     {

--- a/src/Gmagick/Image.php
+++ b/src/Gmagick/Image.php
@@ -38,12 +38,12 @@ final class Image extends AbstractImage
     private $gmagick;
 
     /**
-     * @var Layers|null
+     * @var \Imagine\Gmagick\Layers|null
      */
     private $layers;
 
     /**
-     * @var PaletteInterface
+     * @var \Imagine\Image\Palette\PaletteInterface
      */
     private $palette;
 
@@ -56,8 +56,8 @@ final class Image extends AbstractImage
      * Constructs a new Image instance.
      *
      * @param \Gmagick $gmagick
-     * @param PaletteInterface $palette
-     * @param MetadataBag $metadata
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
      */
     public function __construct(\Gmagick $gmagick, PaletteInterface $palette, MetadataBag $metadata)
     {
@@ -77,6 +77,11 @@ final class Image extends AbstractImage
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractImage::__clone()
+     */
     public function __clone()
     {
         parent::__clone();
@@ -100,7 +105,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::copy()
      */
     public function copy()
     {
@@ -110,7 +115,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::crop()
      */
     public function crop(PointInterface $start, BoxInterface $size)
     {
@@ -130,7 +135,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::flipHorizontally()
      */
     public function flipHorizontally()
     {
@@ -146,7 +151,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::flipVertically()
      */
     public function flipVertically()
     {
@@ -162,7 +167,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::strip()
      */
     public function strip()
     {
@@ -184,7 +189,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::paste()
      */
     public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
@@ -217,7 +222,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::resize()
      */
     public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -256,7 +261,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::rotate()
      */
     public function rotate($angle, ColorInterface $background = null)
     {
@@ -275,15 +280,13 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
-     * Applies options before save or output
+     * Applies options before save or output.
      *
      * @param \Gmagick $image
      * @param array $options
      * @param string $path
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function applyImageOptions(\Gmagick $image, array $options, $path)
     {
@@ -371,7 +374,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::save()
      */
     public function save($path = null, array $options = array())
     {
@@ -395,7 +398,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::show()
      */
     public function show($format, array $options = array())
     {
@@ -407,6 +410,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::get()
      */
     public function get($format, array $options = array())
     {
@@ -451,6 +456,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::__toString()
      */
     public function __toString()
     {
@@ -459,6 +466,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::draw()
      */
     public function draw()
     {
@@ -467,6 +476,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::effects()
      */
     public function effects()
     {
@@ -475,6 +486,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getSize()
      */
     public function getSize()
     {
@@ -494,7 +507,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::applyMask()
      */
     public function applyMask(ImageInterface $mask)
     {
@@ -521,6 +534,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::mask()
      */
     public function mask()
     {
@@ -538,7 +553,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::fill()
      */
     public function fill(FillInterface $fill)
     {
@@ -572,6 +587,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::histogram()
      */
     public function histogram()
     {
@@ -590,6 +607,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getColorAt()
      */
     public function getColorAt(PointInterface $point)
     {
@@ -621,9 +640,9 @@ final class Image extends AbstractImage
      *
      * @param \GmagickPixel $pixel
      *
-     * @throws InvalidArgumentException In case a unknown color is requested
+     * @throws \Imagine\Exception\InvalidArgumentException In case a unknown color is requested
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function pixelToColor(\GmagickPixel $pixel)
     {
@@ -672,6 +691,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::layers()
      */
     public function layers()
     {
@@ -684,6 +705,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::interlace()
      */
     public function interlace($scheme)
     {
@@ -705,6 +728,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::usePalette()
      */
     public function usePalette(PaletteInterface $palette)
     {
@@ -741,6 +766,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::palette()
      */
     public function palette()
     {
@@ -749,6 +776,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::profile()
      */
     public function profile(ProfileInterface $profile)
     {
@@ -766,8 +795,6 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
      * Flatten the image.
      */
     private function flatten()
@@ -787,9 +814,9 @@ final class Image extends AbstractImage
     /**
      * Gets specifically formatted color string from Color instance.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return \GmagickPixel
      */
@@ -803,13 +830,11 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
      * Get the mime type based on format.
      *
      * @param string $format
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return string mime-type
      */
@@ -836,9 +861,9 @@ final class Image extends AbstractImage
     /**
      * Sets colorspace and image type, assigns the palette.
      *
-     * @param PaletteInterface $palette
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setColorspace(PaletteInterface $palette)
     {
@@ -851,6 +876,9 @@ final class Image extends AbstractImage
         $this->palette = $palette;
     }
 
+    /**
+     * @return array
+     */
     private static function getColorspaceMapping()
     {
         if (self::$colorspaceMapping === null) {

--- a/src/Gmagick/Imagine.php
+++ b/src/Gmagick/Imagine.php
@@ -31,7 +31,7 @@ use Imagine\Image\Palette\RGB;
 class Imagine extends AbstractImagine
 {
     /**
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      */
     public function __construct()
     {
@@ -42,6 +42,8 @@ class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::open()
      */
     public function open($path)
     {
@@ -64,6 +66,8 @@ class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::create()
      */
     public function create(BoxInterface $size, ColorInterface $color = null)
     {
@@ -108,6 +112,8 @@ class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::load()
      */
     public function load($string)
     {
@@ -116,6 +122,8 @@ class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::read()
      */
     public function read($resource)
     {
@@ -134,12 +142,21 @@ class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::font()
      */
     public function font($file, $size, ColorInterface $color)
     {
         return $this->getClassFactory()->createFont(ClassFactoryInterface::HANDLE_GMAGICK, $file, $size, $color);
     }
 
+    /**
+     * @param \Gmagick $gmagick
+     *
+     * @throws \Imagine\Exception\NotSupportedException
+     *
+     * @return \Imagine\Image\Palette\PaletteInterface
+     */
     private function createPalette(\Gmagick $gmagick)
     {
         switch ($gmagick->getimagecolorspace()) {
@@ -155,6 +172,14 @@ class Imagine extends AbstractImagine
         }
     }
 
+    /**
+     * @param string $content
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
+     *
+     * @throws \Imagine\Exception\RuntimeException
+     *
+     * @return \Imagine\Image\ImageInterface
+     */
     private function doLoad($content, MetadataBag $metadata)
     {
         try {

--- a/src/Gmagick/Layers.php
+++ b/src/Gmagick/Layers.php
@@ -23,7 +23,7 @@ use Imagine\Image\Palette\PaletteInterface;
 class Layers extends AbstractLayers
 {
     /**
-     * @var Image
+     * @var \Imagine\Gmagick\Image
      */
     private $image;
 
@@ -38,15 +38,21 @@ class Layers extends AbstractLayers
     private $offset;
 
     /**
-     * @var array
+     * @var \Imagine\Gmagick\Image[]
      */
     private $layers = array();
 
     /**
-     * @var PaletteInterface
+     * @var \Imagine\Image\Palette\PaletteInterface
      */
     private $palette;
 
+    /**
+     * @param \Imagine\Gmagick\Image $image
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Gmagick $resource
+     * @param int $initialOffset
+     */
     public function __construct(Image $image, PaletteInterface $palette, \Gmagick $resource, $initialOffset = 0)
     {
         $this->image = $image;
@@ -57,6 +63,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::merge()
      */
     public function merge()
     {
@@ -72,6 +80,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::coalesce()
      */
     public function coalesce()
     {
@@ -80,6 +90,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::animate()
      */
     public function animate($format, $delay, $loops)
     {
@@ -115,6 +127,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::current()
      */
     public function current()
     {
@@ -126,9 +140,9 @@ class Layers extends AbstractLayers
      *
      * @param int $offset
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return Image
+     * @return \Imagine\Gmagick\Image
      */
     private function extractAt($offset)
     {
@@ -146,6 +160,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::key()
      */
     public function key()
     {
@@ -154,6 +170,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::next()
      */
     public function next()
     {
@@ -162,6 +180,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
      */
     public function rewind()
     {
@@ -170,6 +190,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
      */
     public function valid()
     {
@@ -178,6 +200,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Countable::count()
      */
     public function count()
     {
@@ -190,6 +214,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetExists()
      */
     public function offsetExists($offset)
     {
@@ -198,6 +224,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetGet()
      */
     public function offsetGet($offset)
     {
@@ -206,6 +234,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetSet()
      */
     public function offsetSet($offset, $image)
     {
@@ -257,6 +287,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetUnset()
      */
     public function offsetUnset($offset)
     {

--- a/src/Image/AbstractFont.php
+++ b/src/Image/AbstractFont.php
@@ -37,7 +37,7 @@ abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
     protected $size;
 
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     protected $color;
 
@@ -48,7 +48,7 @@ abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
      *
      * @param string $file
      * @param int $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      */
     public function __construct($file, $size, ColorInterface $color)
     {
@@ -59,6 +59,8 @@ abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::getFile()
      */
     final public function getFile()
     {
@@ -67,6 +69,8 @@ abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::getSize()
      */
     final public function getSize()
     {
@@ -75,6 +79,8 @@ abstract class AbstractFont implements FontInterface, ClassFactoryAwareInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::getColor()
      */
     final public function getColor()
     {

--- a/src/Image/AbstractImage.php
+++ b/src/Image/AbstractImage.php
@@ -15,12 +15,11 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\Factory\ClassFactory;
 use Imagine\Factory\ClassFactoryAwareInterface;
 use Imagine\Factory\ClassFactoryInterface;
-use Imagine\Image\Metadata\MetadataBag;
 
 abstract class AbstractImage implements ImageInterface, ClassFactoryAwareInterface
 {
     /**
-     * @var MetadataBag
+     * @var \Imagine\Image\Metadata\MetadataBag
      */
     protected $metadata;
 
@@ -32,7 +31,7 @@ abstract class AbstractImage implements ImageInterface, ClassFactoryAwareInterfa
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @see \Imagine\Image\ManipulatorInterface::thumbnail()
      */
     public function thumbnail(BoxInterface $size, $settings = ImageInterface::THUMBNAIL_INSET, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -169,6 +168,8 @@ abstract class AbstractImage implements ImageInterface, ClassFactoryAwareInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::metadata()
      */
     public function metadata()
     {
@@ -176,7 +177,7 @@ abstract class AbstractImage implements ImageInterface, ClassFactoryAwareInterfa
     }
 
     /**
-     * Assures the metadata instance will be cloned, too.
+     * Clones all the resources associated to this instance.
      */
     public function __clone()
     {

--- a/src/Image/AbstractImagine.php
+++ b/src/Image/AbstractImagine.php
@@ -86,7 +86,7 @@ abstract class AbstractImagine implements ImagineInterface
      *
      * @param string|object $path
      *
-     * @throws InvalidArgumentException in case the given path is invalid
+     * @throws \Imagine\Exception\InvalidArgumentException in case the given path is invalid
      *
      * @return string
      */

--- a/src/Image/AbstractLayers.php
+++ b/src/Image/AbstractLayers.php
@@ -24,6 +24,8 @@ abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInter
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::add()
      */
     public function add(ImageInterface $image)
     {
@@ -34,6 +36,8 @@ abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInter
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::set()
      */
     public function set($offset, ImageInterface $image)
     {
@@ -44,6 +48,8 @@ abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInter
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::remove()
      */
     public function remove($offset)
     {
@@ -54,6 +60,8 @@ abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInter
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::get()
      */
     public function get($offset)
     {
@@ -62,6 +70,8 @@ abstract class AbstractLayers implements LayersInterface, ClassFactoryAwareInter
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::has()
      */
     public function has($offset)
     {

--- a/src/Image/Box.php
+++ b/src/Image/Box.php
@@ -34,7 +34,7 @@ final class Box implements BoxInterface
      * @param int $width
      * @param int $height
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     public function __construct($width, $height)
     {
@@ -48,6 +48,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::getWidth()
      */
     public function getWidth()
     {
@@ -56,6 +58,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::getHeight()
      */
     public function getHeight()
     {
@@ -64,6 +68,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::scale()
      */
     public function scale($ratio)
     {
@@ -75,6 +81,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::increase()
      */
     public function increase($size)
     {
@@ -83,6 +91,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::contains()
      */
     public function contains(BoxInterface $box, PointInterface $start = null)
     {
@@ -93,6 +103,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::square()
      */
     public function square()
     {
@@ -101,6 +113,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::__toString()
      */
     public function __toString()
     {
@@ -109,6 +123,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::widen()
      */
     public function widen($width)
     {
@@ -117,6 +133,8 @@ final class Box implements BoxInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\BoxInterface::heighten()
      */
     public function heighten($height)
     {

--- a/src/Image/BoxInterface.php
+++ b/src/Image/BoxInterface.php
@@ -17,14 +17,14 @@ namespace Imagine\Image;
 interface BoxInterface
 {
     /**
-     * Gets current image height.
+     * Gets box height.
      *
      * @return int
      */
     public function getHeight();
 
     /**
-     * Gets current image width.
+     * Gets box width.
      *
      * @return int
      */
@@ -35,7 +35,7 @@ interface BoxInterface
      *
      * @param float $ratio
      *
-     * @return BoxInterface
+     * @return static
      */
     public function scale($ratio);
 
@@ -44,7 +44,7 @@ interface BoxInterface
      *
      * @param int $size
      *
-     * @return BoxInterface
+     * @return static
      */
     public function increase($size);
 
@@ -52,8 +52,8 @@ interface BoxInterface
      * Checks whether current box can fit given box at a given start position,
      * start position defaults to top left corner xy(0,0).
      *
-     * @param BoxInterface $box
-     * @param PointInterface $start
+     * @param \Imagine\Image\BoxInterface $box
+     * @param \Imagine\Image\PointInterface $start
      *
      * @return bool
      */
@@ -79,7 +79,7 @@ interface BoxInterface
      *
      * @param int $width
      *
-     * @return BoxInterface
+     * @return static
      */
     public function widen($width);
 
@@ -88,7 +88,7 @@ interface BoxInterface
      *
      * @param int $height
      *
-     * @return BoxInterface
+     * @return static
      */
     public function heighten($height);
 }

--- a/src/Image/Fill/FillInterface.php
+++ b/src/Image/Fill/FillInterface.php
@@ -11,7 +11,6 @@
 
 namespace Imagine\Image\Fill;
 
-use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\PointInterface;
 
 /**
@@ -22,9 +21,9 @@ interface FillInterface
     /**
      * Gets color of the fill for the given position.
      *
-     * @param PointInterface $position
+     * @param \Imagine\Image\PointInterface $position
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function getColor(PointInterface $position);
 }

--- a/src/Image/Fill/Gradient/Horizontal.php
+++ b/src/Image/Fill/Gradient/Horizontal.php
@@ -20,6 +20,8 @@ final class Horizontal extends Linear
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Fill\Gradient\Linear::getDistance()
      */
     public function getDistance(PointInterface $position)
     {

--- a/src/Image/Fill/Gradient/Linear.php
+++ b/src/Image/Fill/Gradient/Linear.php
@@ -26,12 +26,12 @@ abstract class Linear implements FillInterface
     private $length;
 
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     private $start;
 
     /**
-     * @var ColorInterface
+     * @var \Imagine\Image\Palette\Color\ColorInterface
      */
     private $end;
 
@@ -40,8 +40,8 @@ abstract class Linear implements FillInterface
      * end shades, which default to 0 and 255 accordingly.
      *
      * @param int $length
-     * @param ColorInterface $start
-     * @param ColorInterface $end
+     * @param \Imagine\Image\Palette\Color\ColorInterface $start
+     * @param \Imagine\Image\Palette\Color\ColorInterface $end
      */
     final public function __construct($length, ColorInterface $start, ColorInterface $end)
     {
@@ -52,6 +52,8 @@ abstract class Linear implements FillInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Fill\FillInterface::getColor()
      */
     final public function getColor(PointInterface $position)
     {
@@ -69,7 +71,7 @@ abstract class Linear implements FillInterface
     }
 
     /**
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     final public function getStart()
     {
@@ -77,7 +79,7 @@ abstract class Linear implements FillInterface
     }
 
     /**
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     final public function getEnd()
     {
@@ -87,7 +89,7 @@ abstract class Linear implements FillInterface
     /**
      * Get the distance of the position relative to the beginning of the gradient.
      *
-     * @param PointInterface $position
+     * @param \Imagine\Image\PointInterface $position
      *
      * @return int
      */

--- a/src/Image/Fill/Gradient/Vertical.php
+++ b/src/Image/Fill/Gradient/Vertical.php
@@ -20,6 +20,8 @@ final class Vertical extends Linear
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Fill\Gradient\Linear::getDistance()
      */
     public function getDistance(PointInterface $position)
     {

--- a/src/Image/FontInterface.php
+++ b/src/Image/FontInterface.php
@@ -11,8 +11,6 @@
 
 namespace Imagine\Image;
 
-use Imagine\Image\Palette\Color\ColorInterface;
-
 /**
  * The font interface.
  */
@@ -35,7 +33,7 @@ interface FontInterface
     /**
      * Gets font's color.
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function getColor();
 
@@ -45,7 +43,7 @@ interface FontInterface
      * @param string $string
      * @param int $angle
      *
-     * @return BoxInterface
+     * @return \Imagine\Image\BoxInterface
      */
     public function box($string, $angle = 0);
 }

--- a/src/Image/Histogram/Bucket.php
+++ b/src/Image/Histogram/Bucket.php
@@ -17,7 +17,7 @@ namespace Imagine\Image\Histogram;
 final class Bucket implements \Countable
 {
     /**
-     * @var Range
+     * @var \Imagine\Image\Histogram\Range
      */
     private $range;
 
@@ -27,7 +27,7 @@ final class Bucket implements \Countable
     private $count;
 
     /**
-     * @param Range $range
+     * @param \Imagine\Image\Histogram\Range $range
      * @param int $count
      */
     public function __construct(Range $range, $count = 0)
@@ -38,6 +38,8 @@ final class Bucket implements \Countable
 
     /**
      * @param int $value
+     *
+     * @return $this
      */
     public function add($value)
     {

--- a/src/Image/Histogram/Range.php
+++ b/src/Image/Histogram/Range.php
@@ -32,7 +32,7 @@ final class Range
      * @param int $start
      * @param int $end
      *
-     * @throws OutOfBoundsException
+     * @throws \Imagine\Exception\OutOfBoundsException
      */
     public function __construct($start, $end)
     {

--- a/src/Image/ImageInterface.php
+++ b/src/Image/ImageInterface.php
@@ -11,11 +11,6 @@
 
 namespace Imagine\Image;
 
-use Imagine\Draw\DrawerInterface;
-use Imagine\Effects\EffectsInterface;
-use Imagine\Exception\OutOfBoundsException;
-use Imagine\Exception\RuntimeException;
-use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\Palette\PaletteInterface;
 
 /**
@@ -23,29 +18,158 @@ use Imagine\Image\Palette\PaletteInterface;
  */
 interface ImageInterface extends ManipulatorInterface
 {
+    /**
+     * Resolution units: pixels per inch.
+     *
+     * @var string
+     */
     const RESOLUTION_PIXELSPERINCH = 'ppi';
+
+    /**
+     * Resolution units: pixels per centimeter.
+     *
+     * @var string
+     */
     const RESOLUTION_PIXELSPERCENTIMETER = 'ppc';
 
+    /**
+     * Image interlacing: none.
+     *
+     * @var string
+     */
     const INTERLACE_NONE = 'none';
+
+    /**
+     * Image interlacing: scanline.
+     *
+     * @var string
+     */
     const INTERLACE_LINE = 'line';
+
+    /**
+     * Image interlacing: plane.
+     *
+     * @var string
+     */
     const INTERLACE_PLANE = 'plane';
+
+    /**
+     * Image interlacing: like plane interlacing except the different planes are saved to individual files.
+     *
+     * @var string
+     */
     const INTERLACE_PARTITION = 'partition';
 
+    /**
+     * Image filter: none/undefined.
+     *
+     * @var string
+     */
     const FILTER_UNDEFINED = 'undefined';
+
+    /**
+     * Resampling filter: point (interpolated).
+     *
+     * @var string
+     */
     const FILTER_POINT = 'point';
+
+    /**
+     * Resampling filter: box.
+     *
+     * @var string
+     */
     const FILTER_BOX = 'box';
+
+    /**
+     * Resampling filter: triangle.
+     *
+     * @var string
+     */
     const FILTER_TRIANGLE = 'triangle';
+
+    /**
+     * Resampling filter: hermite.
+     *
+     * @var string
+     */
     const FILTER_HERMITE = 'hermite';
+
+    /**
+     * Resampling filter: hanning.
+     *
+     * @var string
+     */
     const FILTER_HANNING = 'hanning';
+
+    /**
+     * Resampling filter: hamming.
+     *
+     * @var string
+     */
     const FILTER_HAMMING = 'hamming';
+
+    /**
+     * Resampling filter: blackman.
+     *
+     * @var string
+     */
     const FILTER_BLACKMAN = 'blackman';
+
+    /**
+     * Resampling filter: gaussian.
+     *
+     * @var string
+     */
     const FILTER_GAUSSIAN = 'gaussian';
+
+    /**
+     * Resampling filter: quadratic.
+     *
+     * @var string
+     */
     const FILTER_QUADRATIC = 'quadratic';
+
+    /**
+     * Resampling filter: cubic.
+     *
+     * @var string
+     */
     const FILTER_CUBIC = 'cubic';
+
+    /**
+     * Resampling filter: catrom.
+     *
+     * @var string
+     */
     const FILTER_CATROM = 'catrom';
+
+    /**
+     * Resampling filter: mitchell.
+     *
+     * @var string
+     */
     const FILTER_MITCHELL = 'mitchell';
+
+    /**
+     * Resampling filter: lanczos.
+     *
+     * @var string
+     */
     const FILTER_LANCZOS = 'lanczos';
+
+    /**
+     * Resampling filter: bessel.
+     *
+     * @var string
+     */
     const FILTER_BESSEL = 'bessel';
+
+    /**
+     * Resampling filter: sinc.
+     *
+     * @var string
+     */
     const FILTER_SINC = 'sinc';
 
     /**
@@ -54,7 +178,7 @@ interface ImageInterface extends ManipulatorInterface
      * @param string $format
      * @param array $options
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return string binary
      */
@@ -63,7 +187,7 @@ interface ImageInterface extends ManipulatorInterface
     /**
      * Returns the image content as a PNG binary string.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return string binary
      */
@@ -72,19 +196,19 @@ interface ImageInterface extends ManipulatorInterface
     /**
      * Instantiates and returns a DrawerInterface instance for image drawing.
      *
-     * @return DrawerInterface
+     * @return \Imagine\Draw\DrawerInterface
      */
     public function draw();
 
     /**
-     * @return EffectsInterface
+     * @return \Imagine\Effects\EffectsInterface
      */
     public function effects();
 
     /**
      * Returns current image size.
      *
-     * @return BoxInterface
+     * @return \Imagine\Image\BoxInterface
      */
     public function getSize();
 
@@ -92,35 +216,35 @@ interface ImageInterface extends ManipulatorInterface
      * Transforms creates a grayscale mask from current image, returns a new
      * image, while keeping the existing image unmodified.
      *
-     * @return ImageInterface
+     * @return static
      */
     public function mask();
 
     /**
      * Returns array of image colors as Imagine\Image\Palette\Color\ColorInterface instances.
      *
-     * @return array
+     * @return \Imagine\Image\Palette\Color\ColorInterface[]
      */
     public function histogram();
 
     /**
      * Returns color at specified positions of current image.
      *
-     * @param PointInterface $point
+     * @param \Imagine\Image\PointInterface $point
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function getColorAt(PointInterface $point);
 
     /**
      * Returns the image layers when applicable.
      *
-     * @throws RuntimeException In case the layer can not be returned
-     * @throws OutOfBoundsException In case the index is not a valid value
+     * @throws \Imagine\Exception\RuntimeException In case the layer can not be returned
+     * @throws \Imagine\Exception\OutOfBoundsException In case the index is not a valid value
      *
-     * @return LayersInterface
+     * @return \Imagine\Image\LayersInterface
      */
     public function layers();
 
@@ -131,43 +255,43 @@ interface ImageInterface extends ManipulatorInterface
      *
      * @throws \Imagine\Exception\InvalidArgumentException When an unsupported Interface type is supplied
      *
-     * @return ImageInterface
+     * @return $this
      */
     public function interlace($scheme);
 
     /**
      * Return the current color palette.
      *
-     * @return PaletteInterface
+     * @return \Imagine\Image\Palette\PaletteInterface
      */
     public function palette();
 
     /**
      * Set a palette for the image. Useful to change colorspace.
      *
-     * @param PaletteInterface $palette
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return $this
      */
     public function usePalette(PaletteInterface $palette);
 
     /**
      * Applies a color profile on the Image.
      *
-     * @param ProfileInterface $profile
+     * @param \Imagine\Image\ProfileInterface $profile
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return $this
      */
     public function profile(ProfileInterface $profile);
 
     /**
      * Returns the Image's meta data.
      *
-     * @return Metadata\MetadataBag
+     * @return \Imagine\Image\Metadata\MetadataBag
      */
     public function metadata();
 }

--- a/src/Image/ImagineInterface.php
+++ b/src/Image/ImagineInterface.php
@@ -11,8 +11,6 @@
 
 namespace Imagine\Image;
 
-use Imagine\Exception\InvalidArgumentException;
-use Imagine\Exception\RuntimeException;
 use Imagine\Factory\ClassFactoryAwareInterface;
 use Imagine\Image\Metadata\MetadataReaderInterface;
 use Imagine\Image\Palette\Color\ColorInterface;
@@ -27,13 +25,13 @@ interface ImagineInterface extends ClassFactoryAwareInterface
     /**
      * Creates a new empty image with an optional background color.
      *
-     * @param BoxInterface $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\BoxInterface $size
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @throws InvalidArgumentException
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function create(BoxInterface $size, ColorInterface $color = null);
 
@@ -42,9 +40,9 @@ interface ImagineInterface extends ClassFactoryAwareInterface
      *
      * @param string|\Imagine\File\LoaderInterface|mixed $path the file path, a LoaderInterface instance, or an object whose string representation is the image path
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function open($path);
 
@@ -53,9 +51,9 @@ interface ImagineInterface extends ClassFactoryAwareInterface
      *
      * @param string $string
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function load($string);
 
@@ -64,9 +62,9 @@ interface ImagineInterface extends ClassFactoryAwareInterface
      *
      * @param resource $resource
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function read($resource);
 
@@ -77,9 +75,9 @@ interface ImagineInterface extends ClassFactoryAwareInterface
      *
      * @param string $file
      * @param int $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
-     * @return FontInterface
+     * @return \Imagine\Image\FontInterface
      */
     public function font($file, $size, ColorInterface $color);
 

--- a/src/Image/LayersInterface.php
+++ b/src/Image/LayersInterface.php
@@ -11,10 +11,6 @@
 
 namespace Imagine\Image;
 
-use Imagine\Exception\InvalidArgumentException;
-use Imagine\Exception\OutOfBoundsException;
-use Imagine\Exception\RuntimeException;
-
 /**
  * The layers interface.
  */
@@ -23,7 +19,7 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
     /**
      * Merge layers into the original objects.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      */
     public function merge();
 
@@ -34,10 +30,10 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
      * @param int $delay The delay in milliseconds between two frames
      * @param int $loops The number of loops, 0 means infinite
      *
-     * @throws InvalidArgumentException In case an invalid argument is provided
-     * @throws RuntimeException In case the driver fails to animate
+     * @throws \Imagine\Exception\InvalidArgumentException In case an invalid argument is provided
+     * @throws \Imagine\Exception\RuntimeException In case the driver fails to animate
      *
-     * @return LayersInterface
+     * @return $this
      */
     public function animate($format, $delay, $loops);
 
@@ -54,11 +50,11 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
     /**
      * Adds an image at the end of the layers stack.
      *
-     * @param ImageInterface $image
+     * @param \Imagine\Image\ImageInterface $image
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return LayersInterface
+     * @return $this
      */
     public function add(ImageInterface $image);
 
@@ -66,13 +62,13 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
      * Set an image at offset.
      *
      * @param int $offset
-     * @param ImageInterface $image
+     * @param \Imagine\Image\ImageInterface $image
      *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
-     * @throws OutOfBoundsException
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
+     * @throws \Imagine\Exception\OutOfBoundsException
      *
-     * @return LayersInterface
+     * @return $this
      */
     public function set($offset, ImageInterface $image);
 
@@ -81,10 +77,10 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
      *
      * @param int $offset
      *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
-     * @return LayersInterface
+     * @return $this
      */
     public function remove($offset);
 
@@ -93,10 +89,10 @@ interface LayersInterface extends \Iterator, \Countable, \ArrayAccess
      *
      * @param int $offset
      *
-     * @throws RuntimeException
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function get($offset);
 

--- a/src/Image/ManipulatorInterface.php
+++ b/src/Image/ManipulatorInterface.php
@@ -11,9 +11,6 @@
 
 namespace Imagine\Image;
 
-use Imagine\Exception\InvalidArgumentException;
-use Imagine\Exception\OutOfBoundsException;
-use Imagine\Exception\RuntimeException;
 use Imagine\Image\Fill\FillInterface;
 use Imagine\Image\Palette\Color\ColorInterface;
 
@@ -46,7 +43,7 @@ interface ManipulatorInterface
     /**
      * Copies current source image into a new ImageInterface instance.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return static
      */
@@ -56,25 +53,25 @@ interface ManipulatorInterface
      * Crops a specified box out of the source image (modifies the source image)
      * Returns cropped self.
      *
-     * @param PointInterface $start
-     * @param BoxInterface $size
+     * @param \Imagine\Image\PointInterface $start
+     * @param \Imagine\Image\BoxInterface $size
      *
-     * @throws OutOfBoundsException
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\OutOfBoundsException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function crop(PointInterface $start, BoxInterface $size);
 
     /**
      * Resizes current image and returns self.
      *
-     * @param BoxInterface $size
+     * @param \Imagine\Image\BoxInterface $size
      * @param string $filter
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED);
 
@@ -84,11 +81,11 @@ interface ManipulatorInterface
      * area of rotated image.
      *
      * @param int $angle
-     * @param ColorInterface $background
+     * @param \Imagine\Image\Palette\Color\ColorInterface $background
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function rotate($angle, ColorInterface $background = null);
 
@@ -99,15 +96,15 @@ interface ManipulatorInterface
      *
      * Returns source image
      *
-     * @param ImageInterface $image
-     * @param PointInterface $start
+     * @param \Imagine\Image\ImageInterface $image
+     * @param \Imagine\Image\PointInterface $start
      * @param int $alpha How to paste the image, from 0 (fully transparent) to 100 (fully opaque)
      *
-     * @throws InvalidArgumentException
-     * @throws OutOfBoundsException
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
+     * @throws \Imagine\Exception\OutOfBoundsException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function paste(ImageInterface $image, PointInterface $start, $alpha = 100);
 
@@ -120,9 +117,9 @@ interface ManipulatorInterface
      * @param string $path
      * @param array $options
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function save($path = null, array $options = array());
 
@@ -132,36 +129,36 @@ interface ManipulatorInterface
      * @param string $format
      * @param array $options
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function show($format, array $options = array());
 
     /**
      * Flips current image using vertical axis.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function flipHorizontally();
 
     /**
      * Flips current image using horizontal axis.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function flipVertically();
 
     /**
      * Remove all profiles and comments.
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return static
+     * @return $this
      */
     public function strip();
 
@@ -169,11 +166,11 @@ interface ManipulatorInterface
      * Generates a thumbnail from a current image
      * Returns it as a new image, doesn't modify the current image.
      *
-     * @param BoxInterface $size
+     * @param \Imagine\Image\BoxInterface $size
      * @param int|string $settings One or more of the ManipulatorInterface::THUMBNAIL_ flags (joined with |). It may be a string for backward compatibility with old constant values that were strings.
      * @param string $filter The filter to use for resizing, one of ImageInterface::FILTER_*
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return static
      */
@@ -182,9 +179,9 @@ interface ManipulatorInterface
     /**
      * Applies a given mask to current image's alpha channel.
      *
-     * @param ImageInterface $mask
+     * @param \Imagine\Image\ImageInterface $mask
      *
-     * @return static
+     * @return $this
      */
     public function applyMask(ImageInterface $mask);
 
@@ -193,9 +190,9 @@ interface ManipulatorInterface
      * the current image with corresponding color from FillInterface, and
      * returns modified image.
      *
-     * @param FillInterface $fill
+     * @param \Imagine\Image\Fill\FillInterface $fill
      *
-     * @return static
+     * @return $this
      */
     public function fill(FillInterface $fill);
 }

--- a/src/Image/Metadata/AbstractMetadataReader.php
+++ b/src/Image/Metadata/AbstractMetadataReader.php
@@ -15,10 +15,15 @@ use Imagine\Exception\InvalidArgumentException;
 use Imagine\File\Loader;
 use Imagine\File\LoaderInterface;
 
+/**
+ * Base class for the default metadata readers.
+ */
 abstract class AbstractMetadataReader implements MetadataReaderInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\MetadataReaderInterface::readFile()
      */
     public function readFile($file)
     {
@@ -29,6 +34,8 @@ abstract class AbstractMetadataReader implements MetadataReaderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\MetadataReaderInterface::readData()
      */
     public function readData($data, $originalResource = null)
     {
@@ -41,6 +48,8 @@ abstract class AbstractMetadataReader implements MetadataReaderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\MetadataReaderInterface::readStream()
      */
     public function readStream($resource)
     {

--- a/src/Image/Metadata/DefaultMetadataReader.php
+++ b/src/Image/Metadata/DefaultMetadataReader.php
@@ -12,12 +12,14 @@
 namespace Imagine\Image\Metadata;
 
 /**
- * Default metadata reader.
+ * A metadata reader that actually doesn't try to extract metadata.
  */
 class DefaultMetadataReader extends AbstractMetadataReader
 {
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromFile()
      */
     protected function extractFromFile($file)
     {
@@ -26,6 +28,8 @@ class DefaultMetadataReader extends AbstractMetadataReader
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromData()
      */
     protected function extractFromData($data)
     {
@@ -34,6 +38,8 @@ class DefaultMetadataReader extends AbstractMetadataReader
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromStream()
      */
     protected function extractFromStream($resource)
     {

--- a/src/Image/Metadata/ExifMetadataReader.php
+++ b/src/Image/Metadata/ExifMetadataReader.php
@@ -20,6 +20,9 @@ use Imagine\File\LoaderInterface;
  */
 class ExifMetadataReader extends AbstractMetadataReader
 {
+    /**
+     * @throws \Imagine\Exception\NotSupportedException
+     */
     public function __construct()
     {
         if (!self::isSupported()) {
@@ -27,6 +30,11 @@ class ExifMetadataReader extends AbstractMetadataReader
         }
     }
 
+    /**
+     * Is this metadata reader supported?
+     *
+     * @return bool
+     */
     public static function isSupported()
     {
         return function_exists('exif_read_data');
@@ -34,6 +42,8 @@ class ExifMetadataReader extends AbstractMetadataReader
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromFile()
      */
     protected function extractFromFile($file)
     {
@@ -44,6 +54,8 @@ class ExifMetadataReader extends AbstractMetadataReader
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromData()
      */
     protected function extractFromData($data)
     {
@@ -52,6 +64,8 @@ class ExifMetadataReader extends AbstractMetadataReader
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Metadata\AbstractMetadataReader::extractFromStream()
      */
     protected function extractFromStream($resource)
     {

--- a/src/Image/Metadata/MetadataBag.php
+++ b/src/Image/Metadata/MetadataBag.php
@@ -12,13 +12,18 @@
 namespace Imagine\Image\Metadata;
 
 /**
- * An interface for Image Metadata.
+ * The container of the data extracted from metadata.
  */
 class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 {
-    /** @var array */
+    /**
+     * @var array
+     */
     private $data;
 
+    /**
+     * @param array $data
+     */
     public function __construct(array $data = array())
     {
         $this->data = $data;
@@ -39,6 +44,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Countable::count()
      */
     public function count()
     {
@@ -47,6 +54,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \IteratorAggregate::getIterator()
      */
     public function getIterator()
     {
@@ -55,6 +64,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetExists()
      */
     public function offsetExists($offset)
     {
@@ -63,6 +74,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetSet()
      */
     public function offsetSet($offset, $value)
     {
@@ -71,6 +84,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetUnset()
      */
     public function offsetUnset($offset)
     {
@@ -79,6 +94,8 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetGet()
      */
     public function offsetGet($offset)
     {
@@ -86,9 +103,9 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
     }
 
     /**
-     * Returns metadata as an array.
+     * Returns metadata as an associative array.
      *
-     * @return array An associative array
+     * @return array
      */
     public function toArray()
     {

--- a/src/Image/Metadata/MetadataReaderInterface.php
+++ b/src/Image/Metadata/MetadataReaderInterface.php
@@ -11,8 +11,9 @@
 
 namespace Imagine\Image\Metadata;
 
-use Imagine\Exception\InvalidArgumentException;
-
+/**
+ * Interface that metadata readers must implement.
+ */
 interface MetadataReaderInterface
 {
     /**
@@ -20,9 +21,9 @@ interface MetadataReaderInterface
      *
      * @param string|\Imagine\File\LoaderInterface $file the path to the file where to read metadata
      *
-     * @throws InvalidArgumentException in case the file does not exist
+     * @throws \Imagine\Exception\InvalidArgumentException in case the file does not exist
      *
-     * @return MetadataBag
+     * @return \Imagine\Image\Metadata\MetadataBag
      */
     public function readFile($file);
 
@@ -32,7 +33,7 @@ interface MetadataReaderInterface
      * @param string $data the binary string to read
      * @param resource $originalResource an optional resource to gather stream metadata
      *
-     * @return MetadataBag
+     * @return \Imagine\Image\Metadata\MetadataBag
      */
     public function readData($data, $originalResource = null);
 
@@ -41,9 +42,9 @@ interface MetadataReaderInterface
      *
      * @param resource $resource the stream to read
      *
-     * @throws InvalidArgumentException in case the resource is not valid
+     * @throws \Imagine\Exception\InvalidArgumentException in case the resource is not valid
      *
-     * @return MetadataBag
+     * @return \Imagine\Image\Metadata\MetadataBag
      */
     public function readStream($resource);
 }

--- a/src/Image/Palette/CMYK.php
+++ b/src/Image/Palette/CMYK.php
@@ -18,10 +18,24 @@ use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\Profile;
 use Imagine\Image\ProfileInterface;
 
+/**
+ * The CMYK palette.
+ */
 class CMYK implements PaletteInterface
 {
+    /**
+     * @var \Imagine\Image\Palette\ColorParser
+     */
     private $parser;
+
+    /**
+     * @var \Imagine\Image\ProfileInterface|null
+     */
     private $profile;
+
+    /**
+     * @var \Imagine\Image\Palette\Color\CMYK[]
+     */
     private static $colors = array();
 
     public function __construct()
@@ -31,6 +45,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::name()
      */
     public function name()
     {
@@ -39,6 +55,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::pixelDefinition()
      */
     public function pixelDefinition()
     {
@@ -52,6 +70,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::supportsAlpha()
      */
     public function supportsAlpha()
     {
@@ -60,6 +80,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::color()
      */
     public function color($color, $alpha = null)
     {
@@ -79,6 +101,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::blend()
      */
     public function blend(ColorInterface $color1, ColorInterface $color2, $amount)
     {
@@ -96,6 +120,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::useProfile()
      */
     public function useProfile(ProfileInterface $profile)
     {
@@ -106,6 +132,8 @@ class CMYK implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::profile()
      */
     public function profile()
     {

--- a/src/Image/Palette/Color/CMYK.php
+++ b/src/Image/Palette/Color/CMYK.php
@@ -38,10 +38,14 @@ final class CMYK implements ColorInterface
     private $k;
 
     /**
-     * @var CMYK
+     * @var \Imagine\Image\Palette\CMYK
      */
     private $palette;
 
+    /**
+     * @param \Imagine\Image\Palette\CMYK $palette
+     * @param int[] $color
+     */
     public function __construct(CMYKPalette $palette, array $color)
     {
         $this->palette = $palette;
@@ -50,6 +54,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getValue()
      */
     public function getValue($component)
     {
@@ -68,7 +74,7 @@ final class CMYK implements ColorInterface
     }
 
     /**
-     * Returns Cyan value of the color.
+     * Returns Cyan value of the color (from 0 to 100).
      *
      * @return int
      */
@@ -78,7 +84,7 @@ final class CMYK implements ColorInterface
     }
 
     /**
-     * Returns Magenta value of the color.
+     * Returns Magenta value of the color (from 0 to 100).
      *
      * @return int
      */
@@ -88,7 +94,7 @@ final class CMYK implements ColorInterface
     }
 
     /**
-     * Returns Yellow value of the color.
+     * Returns Yellow value of the color (from 0 to 100).
      *
      * @return int
      */
@@ -98,7 +104,7 @@ final class CMYK implements ColorInterface
     }
 
     /**
-     * Returns Key value of the color.
+     * Returns Key value of the color (from 0 to 100).
      *
      * @return int
      */
@@ -109,6 +115,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getPalette()
      */
     public function getPalette()
     {
@@ -117,6 +125,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getAlpha()
      */
     public function getAlpha()
     {
@@ -125,6 +135,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::dissolve()
      */
     public function dissolve($alpha)
     {
@@ -133,6 +145,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::lighten()
      */
     public function lighten($shade)
     {
@@ -148,6 +162,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::darken()
      */
     public function darken($shade)
     {
@@ -163,6 +179,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::grayscale()
      */
     public function grayscale()
     {
@@ -179,6 +197,8 @@ final class CMYK implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::isOpaque()
      */
     public function isOpaque()
     {
@@ -198,9 +218,9 @@ final class CMYK implements ColorInterface
     /**
      * Internal, Performs checks for color validity (an of array(C, M, Y, K)).
      *
-     * @param array $color
+     * @param int[] $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setColor(array $color)
     {

--- a/src/Image/Palette/Color/ColorInterface.php
+++ b/src/Image/Palette/Color/ColorInterface.php
@@ -11,19 +11,62 @@
 
 namespace Imagine\Image\Palette\Color;
 
-use Imagine\Image\Palette\PaletteInterface;
-
 interface ColorInterface
 {
+    /**
+     * Channel name: red.
+     *
+     * @var string
+     */
     const COLOR_RED = 'red';
+
+    /**
+     * Channel name: green.
+     *
+     * @var string
+     */
     const COLOR_GREEN = 'green';
+
+    /**
+     * Channel name: blue.
+     *
+     * @var string
+     */
     const COLOR_BLUE = 'blue';
 
+    /**
+     * Channel name: cyan.
+     *
+     * @var string
+     */
     const COLOR_CYAN = 'cyan';
+
+    /**
+     * Channel name: magenta.
+     *
+     * @var string
+     */
     const COLOR_MAGENTA = 'magenta';
+
+    /**
+     * Channel name: yellow.
+     *
+     * @var string
+     */
     const COLOR_YELLOW = 'yellow';
+
+    /**
+     * Channel name: key (black).
+     *
+     * @var string
+     */
     const COLOR_KEYLINE = 'keyline';
 
+    /**
+     * Channel name: gray.
+     *
+     * @var string
+     */
     const COLOR_GRAY = 'gray';
 
     /**
@@ -31,58 +74,59 @@ interface ColorInterface
      *
      * @param string $component One of the ColorInterface::COLOR_* component
      *
-     * @return int
+     * @throws \Imagine\Exception\InvalidArgumentException if $component is not valid
+     *
+     * @return int|null
      */
     public function getValue($component);
 
     /**
-     * Returns percentage of transparency of the color.
+     * Returns percentage of transparency of the color (from 0 - fully transparent, to 100 - fully opaque).
      *
-     * @return int
+     * @return int|null return NULL if the color type does not support transparency
      */
     public function getAlpha();
 
     /**
      * Returns the palette attached to the current color.
      *
-     * @return PaletteInterface
+     * @return \Imagine\Image\Palette\PaletteInterface
      */
     public function getPalette();
 
     /**
-     * Returns a copy of current color, incrementing the alpha channel by the
-     * given amount.
+     * Returns a copy of current color, incrementing the alpha channel by the given amount.
      *
      * @param int $alpha
      *
-     * @return ColorInterface
+     * @throws \Imagine\Exception\RuntimeException if the color type does not support transparency
+     *
+     * @return static
      */
     public function dissolve($alpha);
 
     /**
-     * Returns a copy of the current color, lightened by the specified number
-     * of shades.
+     * Returns a copy of the current color, lightened by the specified number of shades.
      *
      * @param int $shade
      *
-     * @return ColorInterface
+     * @return static
      */
     public function lighten($shade);
 
     /**
-     * Returns a copy of the current color, darkened by the specified number of
-     * shades.
+     * Returns a copy of the current color, darkened by the specified number of shades.
      *
      * @param int $shade
      *
-     * @return ColorInterface
+     * @return static
      */
     public function darken($shade);
 
     /**
      * Returns a gray related to the current color.
      *
-     * @return ColorInterface
+     * @return static
      */
     public function grayscale();
 

--- a/src/Image/Palette/Color/Gray.php
+++ b/src/Image/Palette/Color/Gray.php
@@ -27,10 +27,15 @@ final class Gray implements ColorInterface
     private $alpha;
 
     /**
-     * @var Grayscale
+     * @var \Imagine\Image\Palette\Grayscale
      */
     private $palette;
 
+    /**
+     * @param \Imagine\Image\Palette\Grayscale $palette
+     * @param int[] $color
+     * @param int $alpha
+     */
     public function __construct(Grayscale $palette, array $color, $alpha)
     {
         $this->palette = $palette;
@@ -40,6 +45,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getValue()
      */
     public function getValue($component)
     {
@@ -52,7 +59,7 @@ final class Gray implements ColorInterface
     }
 
     /**
-     * Returns Gray value of the color.
+     * Returns Gray value of the color (from 0 to 255).
      *
      * @return int
      */
@@ -63,6 +70,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getPalette()
      */
     public function getPalette()
     {
@@ -71,6 +80,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getAlpha()
      */
     public function getAlpha()
     {
@@ -79,6 +90,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::dissolve()
      */
     public function dissolve($alpha)
     {
@@ -89,6 +102,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::lighten()
      */
     public function lighten($shade)
     {
@@ -97,6 +112,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::darken()
      */
     public function darken($shade)
     {
@@ -105,6 +122,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::grayscale()
      */
     public function grayscale()
     {
@@ -113,6 +132,8 @@ final class Gray implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::isOpaque()
      */
     public function isOpaque()
     {
@@ -134,7 +155,7 @@ final class Gray implements ColorInterface
      *
      * @param int $alpha
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setAlpha($alpha)
     {
@@ -148,9 +169,9 @@ final class Gray implements ColorInterface
     /**
      * Performs checks for color validity (array of array(gray)).
      *
-     * @param array $color
+     * @param int[] $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setColor(array $color)
     {

--- a/src/Image/Palette/Color/RGB.php
+++ b/src/Image/Palette/Color/RGB.php
@@ -37,10 +37,15 @@ final class RGB implements ColorInterface
     private $alpha;
 
     /**
-     * @var RGBPalette
+     * @var \Imagine\Image\Palette\RGB
      */
     private $palette;
 
+    /**
+     * @param \Imagine\Image\Palette\RGB $palette
+     * @param int[] $color
+     * @param int $alpha
+     */
     public function __construct(RGBPalette $palette, array $color, $alpha)
     {
         $this->palette = $palette;
@@ -50,6 +55,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getValue()
      */
     public function getValue($component)
     {
@@ -66,7 +73,7 @@ final class RGB implements ColorInterface
     }
 
     /**
-     * Returns RED value of the color.
+     * Returns RED value of the color (from 0 to 255).
      *
      * @return int
      */
@@ -76,7 +83,7 @@ final class RGB implements ColorInterface
     }
 
     /**
-     * Returns GREEN value of the color.
+     * Returns GREEN value of the color (from 0 to 255).
      *
      * @return int
      */
@@ -86,7 +93,7 @@ final class RGB implements ColorInterface
     }
 
     /**
-     * Returns BLUE value of the color.
+     * Returns BLUE value of the color (from 0 to 255).
      *
      * @return int
      */
@@ -97,6 +104,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getPalette()
      */
     public function getPalette()
     {
@@ -105,6 +114,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::getAlpha()
      */
     public function getAlpha()
     {
@@ -113,6 +124,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::dissolve()
      */
     public function dissolve($alpha)
     {
@@ -121,6 +134,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::lighten()
      */
     public function lighten($shade)
     {
@@ -135,6 +150,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::darken()
      */
     public function darken($shade)
     {
@@ -149,6 +166,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::grayscale()
      */
     public function grayscale()
     {
@@ -159,6 +178,8 @@ final class RGB implements ColorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\Color\ColorInterface::isOpaque()
      */
     public function isOpaque()
     {
@@ -182,7 +203,7 @@ final class RGB implements ColorInterface
      *
      * @param int $alpha
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setAlpha($alpha)
     {
@@ -200,7 +221,7 @@ final class RGB implements ColorInterface
      *
      * @param array $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setColor(array $color)
     {

--- a/src/Image/Palette/ColorParser.php
+++ b/src/Image/Palette/ColorParser.php
@@ -20,7 +20,7 @@ class ColorParser
      *
      * @param string|array|int $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return array
      */
@@ -44,7 +44,7 @@ class ColorParser
      *
      * @param string|array|int $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return array
      */
@@ -75,7 +75,7 @@ class ColorParser
      *
      * @param string|array|int $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return array
      */
@@ -99,7 +99,7 @@ class ColorParser
      *
      * @param string|array|int $color
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      *
      * @return array
      */

--- a/src/Image/Palette/Grayscale.php
+++ b/src/Image/Palette/Grayscale.php
@@ -17,20 +17,23 @@ use Imagine\Image\Palette\Color\Gray as GrayColor;
 use Imagine\Image\Profile;
 use Imagine\Image\ProfileInterface;
 
+/**
+ * The grayscale palette.
+ */
 class Grayscale implements PaletteInterface
 {
     /**
-     * @var ColorParser
+     * @var \Imagine\Image\Palette\ColorParser
      */
     private $parser;
 
     /**
-     * @var ProfileInterface
+     * @var \Imagine\Image\ProfileInterface|null
      */
     private $profile;
 
     /**
-     * @var array
+     * @var \Imagine\Image\Palette\Color\Gray[]
      */
     protected static $colors = array();
 
@@ -41,6 +44,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::name()
      */
     public function name()
     {
@@ -49,6 +54,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::pixelDefinition()
      */
     public function pixelDefinition()
     {
@@ -57,6 +64,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::supportsAlpha()
      */
     public function supportsAlpha()
     {
@@ -65,6 +74,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::useProfile()
      */
     public function useProfile(ProfileInterface $profile)
     {
@@ -75,6 +86,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::profile()
      */
     public function profile()
     {
@@ -87,6 +100,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::color()
      */
     public function color($color, $alpha = null)
     {
@@ -106,6 +121,8 @@ class Grayscale implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::blend()
      */
     public function blend(ColorInterface $color1, ColorInterface $color2, $amount)
     {

--- a/src/Image/Palette/PaletteInterface.php
+++ b/src/Image/Palette/PaletteInterface.php
@@ -14,32 +14,52 @@ namespace Imagine\Image\Palette;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\ProfileInterface;
 
+/**
+ * Interface that any palette must implement.
+ */
 interface PaletteInterface
 {
+    /**
+     * Palette name: grayscale.
+     *
+     * @var string
+     */
     const PALETTE_GRAYSCALE = 'gray';
+
+    /**
+     * Palette name: RGB.
+     *
+     * @var string
+     */
     const PALETTE_RGB = 'rgb';
+
+    /**
+     * Palette name: CMYK.
+     *
+     * @var string
+     */
     const PALETTE_CMYK = 'cmyk';
 
     /**
      * Returns a color given some values.
      *
-     * @param string|array|int $color A color
+     * @param string|int[]|int $color A color
      * @param int|null $alpha Set alpha to null to disable it
      *
      * @throws \Imagine\Exception\InvalidArgumentException In case you pass an alpha value to a Palette that does not support alpha
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function color($color, $alpha = null);
 
     /**
      * Blend two colors given an amount.
      *
-     * @param ColorInterface $color1
-     * @param ColorInterface $color2
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color1
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color2
      * @param float $amount The amount of color2 in color1
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function blend(ColorInterface $color1, ColorInterface $color2, $amount);
 
@@ -48,22 +68,21 @@ interface PaletteInterface
      *
      * (A default profile is provided by default)
      *
-     * @param ProfileInterface $profile
+     * @param \Imagine\Image\ProfileInterface $profile
      *
-     * @return PaletteInterface
+     * @return $this
      */
     public function useProfile(ProfileInterface $profile);
 
     /**
      * Returns the ICC profile attached to this Palette.
      *
-     * @return ProfileInterface
+     * @return \Imagine\Image\ProfileInterface
      */
     public function profile();
 
     /**
-     * Returns the name of this Palette, one of PaletteInterface::PALETTE_*
-     * constants.
+     * Returns the name of this Palette, one of PaletteInterface::PALETTE_ constants.
      *
      * @return string
      */
@@ -73,7 +92,7 @@ interface PaletteInterface
      * Returns an array containing ColorInterface::COLOR_* constants that
      * define the structure of colors for a pixel.
      *
-     * @return array
+     * @return string[]
      */
     public function pixelDefinition();
 

--- a/src/Image/Palette/RGB.php
+++ b/src/Image/Palette/RGB.php
@@ -17,20 +17,23 @@ use Imagine\Image\Palette\Color\RGB as RGBColor;
 use Imagine\Image\Profile;
 use Imagine\Image\ProfileInterface;
 
+/**
+ * The RGB palette.
+ */
 class RGB implements PaletteInterface
 {
     /**
-     * @var ColorParser
+     * @var \Imagine\Image\Palette\ColorParser
      */
     private $parser;
 
     /**
-     * @var ProfileInterface
+     * @var \Imagine\Image\ProfileInterface|null
      */
     private $profile;
 
     /**
-     * @var array
+     * @var \Imagine\Image\Palette\Color\RGB[]
      */
     protected static $colors = array();
 
@@ -41,6 +44,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::name()
      */
     public function name()
     {
@@ -49,6 +54,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::pixelDefinition()
      */
     public function pixelDefinition()
     {
@@ -61,6 +68,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::supportsAlpha()
      */
     public function supportsAlpha()
     {
@@ -69,6 +78,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::useProfile()
      */
     public function useProfile(ProfileInterface $profile)
     {
@@ -79,6 +90,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::profile()
      */
     public function profile()
     {
@@ -91,6 +104,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::color()
      */
     public function color($color, $alpha = null)
     {
@@ -110,6 +125,8 @@ class RGB implements PaletteInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\Palette\PaletteInterface::blend()
      */
     public function blend(ColorInterface $color1, ColorInterface $color2, $amount)
     {

--- a/src/Image/Point.php
+++ b/src/Image/Point.php
@@ -34,7 +34,7 @@ final class Point implements PointInterface
      * @param int $x
      * @param int $y
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     public function __construct($x, $y)
     {
@@ -48,6 +48,8 @@ final class Point implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::getX()
      */
     public function getX()
     {
@@ -56,6 +58,8 @@ final class Point implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::getY()
      */
     public function getY()
     {
@@ -64,6 +68,8 @@ final class Point implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::in()
      */
     public function in(BoxInterface $box)
     {
@@ -72,6 +78,8 @@ final class Point implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::move()
      */
     public function move($amount)
     {
@@ -80,6 +88,8 @@ final class Point implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::__toString()
      */
     public function __toString()
     {

--- a/src/Image/Point/Center.php
+++ b/src/Image/Point/Center.php
@@ -16,19 +16,19 @@ use Imagine\Image\Point as OriginalPoint;
 use Imagine\Image\PointInterface;
 
 /**
- * Point center.
+ * Center point of a box.
  */
 final class Center implements PointInterface
 {
     /**
-     * @var BoxInterface
+     * @var \Imagine\Image\BoxInterface
      */
     private $box;
 
     /**
      * Constructs coordinate with size instance, it needs to be relative to.
      *
-     * @param BoxInterface $box
+     * @param \Imagine\Image\BoxInterface $box
      */
     public function __construct(BoxInterface $box)
     {
@@ -37,6 +37,8 @@ final class Center implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::getX()
      */
     public function getX()
     {
@@ -45,6 +47,8 @@ final class Center implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::getY()
      */
     public function getY()
     {
@@ -53,6 +57,8 @@ final class Center implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::in()
      */
     public function in(BoxInterface $box)
     {
@@ -61,6 +67,8 @@ final class Center implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::move()
      */
     public function move($amount)
     {
@@ -69,6 +77,8 @@ final class Center implements PointInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\PointInterface::__toString()
      */
     public function __toString()
     {

--- a/src/Image/PointInterface.php
+++ b/src/Image/PointInterface.php
@@ -33,7 +33,7 @@ interface PointInterface
     /**
      * Checks if current coordinate is inside a given box.
      *
-     * @param BoxInterface $box
+     * @param \Imagine\Image\BoxInterface $box
      *
      * @return bool
      */
@@ -44,7 +44,7 @@ interface PointInterface
      *
      * @param int $amount
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\PointInterface
      */
     public function move($amount);
 

--- a/src/Image/Profile.php
+++ b/src/Image/Profile.php
@@ -13,11 +13,25 @@ namespace Imagine\Image;
 
 use Imagine\Exception\InvalidArgumentException;
 
+/**
+ * The default implementation of ProfileInterface.
+ */
 class Profile implements ProfileInterface
 {
+    /**
+     * @var string
+     */
     private $data;
+
+    /**
+     * @var string
+     */
     private $name;
 
+    /**
+     * @param string $name
+     * @param string $data
+     */
     public function __construct($name, $data)
     {
         $this->name = $name;
@@ -26,6 +40,8 @@ class Profile implements ProfileInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ProfileInterface::name()
      */
     public function name()
     {
@@ -34,6 +50,8 @@ class Profile implements ProfileInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ProfileInterface::data()
      */
     public function data()
     {
@@ -45,9 +63,9 @@ class Profile implements ProfileInterface
      *
      * @param string $path
      *
-     * @throws InvalidArgumentException In case the provided path is not valid
+     * @throws \Imagine\Exception\InvalidArgumentException In case the provided path is not valid
      *
-     * @return Profile
+     * @return static
      */
     public static function fromPath($path)
     {

--- a/src/Imagick/Drawer.php
+++ b/src/Imagick/Drawer.php
@@ -40,6 +40,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::arc()
      */
     public function arc(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $thickness = 1)
     {
@@ -73,6 +75,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::chord()
      */
     public function chord(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -125,6 +129,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::ellipse()
      */
     public function ellipse(PointInterface $center, BoxInterface $size, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -170,6 +176,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::line()
      */
     public function line(PointInterface $start, PointInterface $end, ColorInterface $color, $thickness = 1)
     {
@@ -203,6 +211,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::pieSlice()
      */
     public function pieSlice(PointInterface $center, BoxInterface $size, $start, $end, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -237,6 +247,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::dot()
      */
     public function dot(PointInterface $position, ColorInterface $color)
     {
@@ -266,6 +278,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::polygon()
      */
     public function polygon(array $coordinates, ColorInterface $color, $fill = false, $thickness = 1)
     {
@@ -307,6 +321,8 @@ final class Drawer implements DrawerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Draw\DrawerInterface::text()
      */
     public function text($string, AbstractFont $font, PointInterface $position, $angle = 0, $width = null)
     {
@@ -368,7 +384,7 @@ final class Drawer implements DrawerInterface
     /**
      * Gets specifically formatted color string from ColorInterface instance.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
      * @return string
      */
@@ -381,9 +397,7 @@ final class Drawer implements DrawerInterface
     }
 
     /**
-     * Internal.
-     *
-     * Fits a string into box with given width
+     * Fits a string into box with given width.
      *
      * @param string $string
      * @param \ImagickDraw $text

--- a/src/Imagick/Effects.php
+++ b/src/Imagick/Effects.php
@@ -24,8 +24,16 @@ use Imagine\Utils\Matrix;
  */
 class Effects implements EffectsInterface
 {
+    /**
+     * @var \Imagick
+     */
     private $imagick;
 
+    /**
+     * Initialize the instance.
+     *
+     * @param \Imagick $imagick
+     */
     public function __construct(\Imagick $imagick)
     {
         $this->imagick = $imagick;
@@ -33,6 +41,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::gamma()
      */
     public function gamma($correction)
     {
@@ -47,6 +57,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::negative()
      */
     public function negative()
     {
@@ -61,6 +73,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::grayscale()
      */
     public function grayscale()
     {
@@ -75,6 +89,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::colorize()
      */
     public function colorize(ColorInterface $color)
     {
@@ -93,6 +109,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::sharpen()
      */
     public function sharpen()
     {
@@ -107,6 +125,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::blur()
      */
     public function blur($sigma = 1)
     {
@@ -121,6 +141,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::brightness()
      */
     public function brightness($brightness)
     {
@@ -148,6 +170,8 @@ class Effects implements EffectsInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Effects\EffectsInterface::convolve()
      */
     public function convolve(Matrix $matrix)
     {

--- a/src/Imagick/Font.php
+++ b/src/Imagick/Font.php
@@ -28,7 +28,7 @@ final class Font extends AbstractFont
      * @param \Imagick $imagick
      * @param string $file
      * @param int $size
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      */
     public function __construct(\Imagick $imagick, $file, $size, ColorInterface $color)
     {
@@ -39,6 +39,8 @@ final class Font extends AbstractFont
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\FontInterface::box()
      */
     public function box($string, $angle = 0)
     {

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -39,12 +39,12 @@ final class Image extends AbstractImage
     private $imagick;
 
     /**
-     * @var Layers|null
+     * @var \Imagine\Imagick\Layers|null
      */
     private $layers;
 
     /**
-     * @var PaletteInterface
+     * @var \Imagine\Image\Palette\PaletteInterface
      */
     private $palette;
 
@@ -58,6 +58,9 @@ final class Image extends AbstractImage
      */
     private static $supportsProfiles;
 
+    /**
+     * @var array
+     */
     private static $colorspaceMapping = array(
         PaletteInterface::PALETTE_CMYK => \Imagick::COLORSPACE_CMYK,
         PaletteInterface::PALETTE_RGB => \Imagick::COLORSPACE_RGB,
@@ -68,8 +71,8 @@ final class Image extends AbstractImage
      * Constructs a new Image instance.
      *
      * @param \Imagick $imagick
-     * @param PaletteInterface $palette
-     * @param MetadataBag $metadata
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
+     * @param \Imagine\Image\Metadata\MetadataBag $metadata
      */
     public function __construct(\Imagick $imagick, PaletteInterface $palette, MetadataBag $metadata)
     {
@@ -82,6 +85,11 @@ final class Image extends AbstractImage
         $this->palette = $palette;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Image\AbstractImage::__clone()
+     */
     public function __clone()
     {
         parent::__clone();
@@ -118,7 +126,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function copy()
     {
@@ -132,7 +140,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function crop(PointInterface $start, BoxInterface $size)
     {
@@ -164,7 +172,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function flipHorizontally()
     {
@@ -180,7 +188,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function flipVertically()
     {
@@ -196,7 +204,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function strip()
     {
@@ -218,7 +226,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
@@ -264,6 +272,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ManipulatorInterface::resize()
      */
     public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED)
     {
@@ -287,7 +297,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function rotate($angle, ColorInterface $background = null)
     {
@@ -310,7 +320,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function save($path = null, array $options = array())
     {
@@ -332,7 +342,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function show($format, array $options = array())
     {
@@ -344,6 +354,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::get()
      */
     public function get($format, array $options = array())
     {
@@ -359,6 +371,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::interlace()
      */
     public function interlace($scheme)
     {
@@ -409,6 +423,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::__toString()
      */
     public function __toString()
     {
@@ -417,6 +433,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::draw()
      */
     public function draw()
     {
@@ -425,6 +443,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::effects()
      */
     public function effects()
     {
@@ -433,6 +453,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getSize()
      */
     public function getSize()
     {
@@ -452,7 +474,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function applyMask(ImageInterface $mask)
     {
@@ -486,6 +508,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::mask()
      */
     public function mask()
     {
@@ -504,7 +528,7 @@ final class Image extends AbstractImage
     /**
      * {@inheritdoc}
      *
-     * @return ImageInterface
+     * @return \Imagine\Image\ImageInterface
      */
     public function fill(FillInterface $fill)
     {
@@ -534,6 +558,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::histogram()
      */
     public function histogram()
     {
@@ -552,6 +578,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::getColorAt()
      */
     public function getColorAt(PointInterface $point)
     {
@@ -575,9 +603,9 @@ final class Image extends AbstractImage
      *
      * @param \ImagickPixel $pixel
      *
-     * @throws InvalidArgumentException In case a unknown color is requested
+     * @throws \Imagine\Exception\InvalidArgumentException In case a unknown color is requested
      *
-     * @return ColorInterface
+     * @return \Imagine\Image\Palette\Color\ColorInterface
      */
     public function pixelToColor(\ImagickPixel $pixel)
     {
@@ -614,6 +642,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::layers()
      */
     public function layers()
     {
@@ -626,6 +656,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::usePalette()
      */
     public function usePalette(PaletteInterface $palette)
     {
@@ -663,6 +695,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::palette()
      */
     public function palette()
     {
@@ -671,6 +705,8 @@ final class Image extends AbstractImage
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImageInterface::profile()
      */
     public function profile(ProfileInterface $profile)
     {
@@ -688,8 +724,6 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
      * Flatten the image.
      */
     private function flatten()
@@ -709,16 +743,14 @@ final class Image extends AbstractImage
     }
 
     /**
-     * Internal.
-     *
-     * Applies options before save or output
+     * Applies options before save or output.
      *
      * @param \Imagick $image
      * @param array $options
      * @param string $path
      *
-     * @throws InvalidArgumentException
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\InvalidArgumentException
+     * @throws \Imagine\Exception\RuntimeException
      */
     private function applyImageOptions(\Imagick $image, array $options, $path)
     {
@@ -816,7 +848,7 @@ final class Image extends AbstractImage
     /**
      * Gets specifically formatted color string from Color instance.
      *
-     * @param ColorInterface $color
+     * @param \Imagine\Image\Palette\Color\ColorInterface $color
      *
      * @return \ImagickPixel
      */
@@ -831,7 +863,7 @@ final class Image extends AbstractImage
     /**
      * Checks whether given $fill is linear and opaque.
      *
-     * @param FillInterface $fill
+     * @param \Imagine\Image\Fill\FillInterface $fill
      *
      * @return bool
      */
@@ -843,7 +875,7 @@ final class Image extends AbstractImage
     /**
      * Performs optimized gradient fill for non-opaque linear gradients.
      *
-     * @param Linear $fill
+     * @param \Imagine\Image\Fill\Gradient\Linear $fill
      */
     private function applyFastLinear(Linear $fill)
     {
@@ -870,7 +902,7 @@ final class Image extends AbstractImage
      *
      * @param string $format
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
      * @return string mime-type
      */
@@ -897,9 +929,9 @@ final class Image extends AbstractImage
     /**
      * Sets colorspace and image type, assigns the palette.
      *
-     * @param PaletteInterface $palette
+     * @param \Imagine\Image\Palette\PaletteInterface $palette
      *
-     * @throws InvalidArgumentException
+     * @throws \Imagine\Exception\InvalidArgumentException
      */
     private function setColorspace(PaletteInterface $palette)
     {
@@ -970,7 +1002,7 @@ final class Image extends AbstractImage
      *
      * @param string $filter
      *
-     * @throws InvalidArgumentException if the filter is unsupported
+     * @throws \Imagine\Exception\InvalidArgumentException if the filter is unsupported
      *
      * @return string
      */

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -30,7 +30,7 @@ use Imagine\Image\Palette\RGB;
 final class Imagine extends AbstractImagine
 {
     /**
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      */
     public function __construct()
     {
@@ -47,6 +47,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::open()
      */
     public function open($path)
     {
@@ -76,6 +78,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::create()
      */
     public function create(BoxInterface $size, ColorInterface $color = null)
     {
@@ -114,6 +118,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::load()
      */
     public function load($string)
     {
@@ -131,6 +137,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::read()
      */
     public function read($resource)
     {
@@ -152,6 +160,8 @@ final class Imagine extends AbstractImagine
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\ImagineInterface::font()
      */
     public function font($file, $size, ColorInterface $color)
     {
@@ -163,9 +173,9 @@ final class Imagine extends AbstractImagine
      *
      * @param \Imagick $imagick
      *
-     * @throws NotSupportedException
+     * @throws \Imagine\Exception\NotSupportedException
      *
-     * @return CMYK|Grayscale|RGB
+     * @return \Imagine\Image\Palette\CMYK|\Imagine\Image\Palette\Grayscale|\Imagine\Image\Palette\RGB
      */
     private function createPalette(\Imagick $imagick)
     {

--- a/src/Imagick/Layers.php
+++ b/src/Imagick/Layers.php
@@ -22,22 +22,28 @@ use Imagine\Image\Palette\PaletteInterface;
 class Layers extends AbstractLayers
 {
     /**
-     * @var Image
+     * @var \Imagine\Imagick\Image
      */
     private $image;
+
     /**
      * @var \Imagick
      */
     private $resource;
+
     /**
      * @var int
      */
     private $offset;
+
     /**
-     * @var array
+     * @var \Imagine\Imagick\Image[]
      */
     private $layers = array();
 
+    /**
+     * @var \Imagine\Image\Palette\PaletteInterface
+     */
     private $palette;
 
     public function __construct(Image $image, PaletteInterface $palette, \Imagick $resource, $initialOffset = 0)
@@ -50,6 +56,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::merge()
      */
     public function merge()
     {
@@ -65,6 +73,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::animate()
      */
     public function animate($format, $delay, $loops)
     {
@@ -102,6 +112,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Imagine\Image\LayersInterface::coalesce()
      */
     public function coalesce()
     {
@@ -126,6 +138,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::current()
      */
     public function current()
     {
@@ -137,9 +151,9 @@ class Layers extends AbstractLayers
      *
      * @param int $offset
      *
-     * @throws RuntimeException
+     * @throws \Imagine\Exception\RuntimeException
      *
-     * @return Image
+     * @return \Imagine\Imagick\Image
      */
     private function extractAt($offset)
     {
@@ -157,6 +171,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::key()
      */
     public function key()
     {
@@ -165,6 +181,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::next()
      */
     public function next()
     {
@@ -173,6 +191,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
      */
     public function rewind()
     {
@@ -181,6 +201,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
      */
     public function valid()
     {
@@ -189,6 +211,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \Countable::count()
      */
     public function count()
     {
@@ -201,6 +225,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetExists()
      */
     public function offsetExists($offset)
     {
@@ -209,6 +235,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetGet()
      */
     public function offsetGet($offset)
     {
@@ -217,6 +245,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetSet()
      */
     public function offsetSet($offset, $image)
     {
@@ -257,6 +287,8 @@ class Layers extends AbstractLayers
 
     /**
      * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetUnset()
      */
     public function offsetUnset($offset)
     {


### PR DESCRIPTION
I reviewed all the phpdocs of Imagine, and here's a list of edits:

- I added phpdoc to (almost) everything in the `src` directory
- I fixed [one wrong phpdoc](https://github.com/mlocati/Imagine/commit/0d22dc3b50ce4752b596bf673bae7b1a7ee7bb2c#diff-32a08e6820d097c40f318189f1b3ac96L47)
- I used `$this` in `@return` statements when a method always returns the same instance of the called class (so it's clear that these are not immutable methods for example), and `@return static` to state that a method returns a new instance.
- I removed the `/** Internal. **/` comments for private methods: they are private, it's obvious that they are internal.
- I used fully-qualified class names.  
  Why?
  - even if IDEs can understand `use` statements, phpdoc are useful for humans too: when I visually take a look at the code, I don't want to jump at the top of a file to see if `RGB` is a palette or a color
  - it's useful to see the FQ names so that I can copy-and-paste the class names in my code
  - we avoid `use` statements for classes that are only used in phpdoc and not in actual PHP code
- I added `@see` statements in addition to `{@inheritdoc}`: we have so many interfaces and classes that it's not always clear where a method is defined. Sure, IDEs can understand it, but humans may have a hard time.