### PR TITLE
New imagick save option: optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 bin/
 /.php_cs.cache
 /.php_cs
+/tests/tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     **BREAKING CHANGE** if you have your own `ColorInterface` implementation, it now must implement `__toString`
   * New Imagick save option: `optimize` if set, the size of animated GIF files is optimized (@mlocati)  
     **NOTE** Imagick requires that the image frames have the same size
+
 ### 1.0.0-alpha1 (2018-08-28)
   * Imagine is now tested under Windows too (@mlocati)
   * Add support to webp image format (@chregu, @antoligy, @alexander-schranz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     **BREAKING CHANGE** if you have your own `LayerInterface` implementation, it now must return `$this`
   * The `__toString` method has been added to `ColorInterface` since all its implementations have it (@mlocati)  
     **BREAKING CHANGE** if you have your own `ColorInterface` implementation, it now must implement `__toString`
+  * New Imagick save option: `optimize` if set, the size of animated GIF files is optimized (@mlocati)  
+    **NOTE** Imagick requires that the image frames have the same size
 
 ### 1.0.0-alpha1 (2018-08-28)
   * Imagine is now tested under Windows too (@mlocati)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
     **BREAKING CHANGE** if you have your own `ColorInterface` implementation, it now must implement `__toString`
   * New Imagick save option: `optimize` if set, the size of animated GIF files is optimized (@mlocati)  
     **NOTE** Imagick requires that the image frames have the same size
-
 ### 1.0.0-alpha1 (2018-08-28)
   * Imagine is now tested under Windows too (@mlocati)
   * Add support to webp image format (@chregu, @antoligy, @alexander-schranz)

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -413,7 +413,7 @@ final class Image extends AbstractImage
         } else {
             $this->layers()->merge();
         }
-        $this->applyImageOptions($this->imagick, $options, $path);
+        $this->imagick = $this->applyImageOptions($this->imagick, $options, $path);
 
         // flatten only if image has multiple layers
         if ((!isset($options['flatten']) || $options['flatten'] === true) && $this->layers()->count() > 1) {
@@ -751,6 +751,8 @@ final class Image extends AbstractImage
      *
      * @throws \Imagine\Exception\InvalidArgumentException
      * @throws \Imagine\Exception\RuntimeException
+     *
+     * @return \Imagick
      */
     private function applyImageOptions(\Imagick $image, array $options, $path)
     {
@@ -843,6 +845,21 @@ final class Image extends AbstractImage
             $image->setImageResolution($options['resolution-x'], $options['resolution-y']);
             $image->resampleImage($options['resolution-x'], $options['resolution-y'], $filter, 0);
         }
+        if (!empty($options['optimize'])) {
+            try {
+                $optimized = $image->optimizeimagelayers();
+            } catch (\ImagickException $e) {
+                throw new RuntimeException('Image optimization failed', $e->getCode(), $e);
+            }
+            if ($optimized === false) {
+                throw new RuntimeException('Image optimization failed');
+            }
+            if ($optimized instanceof \Imagick) {
+                $image = $optimized;
+            }
+        }
+
+        return $image;
     }
 
     /**

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -847,6 +847,7 @@ final class Image extends AbstractImage
         }
         if (!empty($options['optimize'])) {
             try {
+                $image = $image->coalesceImages();
                 $optimized = $image->optimizeimagelayers();
             } catch (\ImagickException $e) {
                 throw new RuntimeException('Image optimization failed', $e->getCode(), $e);

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -173,11 +173,6 @@ class ImageTest extends AbstractImageTest
         unlink($filename);
     }
 
-    protected function supportMultipleLayers()
-    {
-        return true;
-    }
-
     protected function getImageResolution(ImageInterface $image)
     {
         return $image->getImagick()->getImageResolution();

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -141,6 +141,42 @@ class ImageTest extends AbstractImageTest
         unlink('tests/Imagine/Fixtures/crop/anima3-topleft-actual.gif');
     }
 
+    public function testOptimize()
+    {
+        $imagine = $this->getImagine();
+        $rgb = new RGB();
+        $image = $imagine->create(new Box(100, 100), $rgb->color('#fff'));
+        $blackFrame = $imagine->create($image->getSize(), $rgb->color('#000'));
+        $image->layers()->add(clone $blackFrame)->add(clone $blackFrame)->add(clone $blackFrame)->add(clone $blackFrame);
+        $originalFilename = IMAGINE_TEST_TEMPFOLDER . '/not-optimized.gif';
+        $image->save($originalFilename, array('animated' => true, 'optimize' => false));
+        $originalSize = filesize($originalFilename);
+        $optimizedFilename = IMAGINE_TEST_TEMPFOLDER . '/optimized.gif';
+        $image->save($optimizedFilename, array('animated' => true, 'optimize' => true));
+        $optimizedSize = filesize($optimizedFilename);
+        $this->assertLessThan($originalSize, $optimizedSize);
+        unlink($optimizedFilename);
+        unlink($originalFilename);
+    }
+
+    /**
+     * @expectedException \Imagine\Exception\RuntimeException
+     * @expectedExceptionMessage Image optimization failed
+     */
+    public function testOptimizeWithDifferentFrameSizes()
+    {
+        $imagine = $this->getImagine();
+        $rgb = new RGB();
+        $image = $imagine->create(new Box(10, 10), $rgb->color('#fff'));
+        $image->layers()->add($imagine->create($image->getSize()->scale(2)), $rgb->color('#fff'));
+        $image->save(IMAGINE_TEST_TEMPFOLDER . '/should-fail.gif', array('animated' => true, 'optimize' => true));
+    }
+
+    protected function supportMultipleLayers()
+    {
+        return true;
+    }
+
     protected function getImageResolution(ImageInterface $image)
     {
         return $image->getImagick()->getImageResolution();

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -160,8 +160,7 @@ class ImageTest extends AbstractImageTest
     }
 
     /**
-     * @expectedException \Imagine\Exception\RuntimeException
-     * @expectedExceptionMessage Image optimization failed
+     * @doesNotPerformAssertions
      */
     public function testOptimizeWithDifferentFrameSizes()
     {
@@ -169,7 +168,9 @@ class ImageTest extends AbstractImageTest
         $rgb = new RGB();
         $image = $imagine->create(new Box(10, 10), $rgb->color('#fff'));
         $image->layers()->add($imagine->create($image->getSize()->scale(2)), $rgb->color('#fff'));
-        $image->save(IMAGINE_TEST_TEMPFOLDER . '/should-fail.gif', array('animated' => true, 'optimize' => true));
+        $filename = IMAGINE_TEST_TEMPFOLDER . '/optimized.gif';
+        $image->save($filename, array('animated' => true, 'optimize' => true));
+        unlink($filename);
     }
 
     protected function supportMultipleLayers()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,4 +32,9 @@ if (!class_exists('PHPUnit\Framework\ExpectationFailedException')) {
     class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
 }
 
+define('IMAGINE_TEST_TEMPFOLDER', __DIR__ . DIRECTORY_SEPARATOR . 'tmp');
+if (!is_dir(IMAGINE_TEST_TEMPFOLDER)) {
+    mkdir(IMAGINE_TEST_TEMPFOLDER);
+}
+
 chdir(dirname(__DIR__));


### PR DESCRIPTION
Imagick can optimize animated GIF files, ~provided that the frames have the same size~.

Supersedes #252

EDIT: calling `coalesceImages` allows using `optimizeimagelayers` even if the frames have different sizes.