### PR TITLE
Don't execute tests that will always be skipped

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,6 @@ build: off
 test_script:
   - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
   - cd /d "%APPVEYOR_BUILD_FOLDER%"
-  - composer test -- --exclude-group ext-gmagick
+  - composer test -- --exclude-group always-skipped,ext-gmagick
 
 deploy: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
             sudo apt-get remove -y imagemagick libmagickcore-dev libmagickwand-dev
             sudo apt-get update -y || true
             sudo apt-get install -y ca-certificates libtiff-dev libjpeg-dev libdjvulibre-dev libwmf-dev pkg-config liblcms2-dev
-            PHPUNIT_EXCLUDED_GROUPS=none
+            PHPUNIT_EXCLUDED_GROUPS=always-skipped
             if test "${IMAGINE_DRIVER}" = 'imagick'; then ./.travis/imagick.sh; else PHPUNIT_EXCLUDED_GROUPS="${PHPUNIT_EXCLUDED_GROUPS},ext-imagick"; fi
             if test "${IMAGINE_DRIVER}" = 'gmagick'; then ./.travis/gmagick.sh; else PHPUNIT_EXCLUDED_GROUPS="${PHPUNIT_EXCLUDED_GROUPS},ext-gmagick"; fi
             composer --no-interaction remove --dev --no-update --no-scripts friendsofphp/php-cs-fixer

--- a/tests/Imagine/Test/Gd/ImageTest.php
+++ b/tests/Imagine/Test/Gd/ImageTest.php
@@ -29,6 +29,13 @@ class ImageTest extends AbstractImageTest
         }
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testImageResolutionChange()
+     */
     public function testImageResolutionChange()
     {
         $this->markTestSkipped('GD driver does not support resolution options');
@@ -67,31 +74,73 @@ class ImageTest extends AbstractImageTest
         parent::testProfile();
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testPaletteIsGrayIfGrayImage()
+     */
     public function testPaletteIsGrayIfGrayImage()
     {
         $this->markTestSkipped('GD driver does not support Gray colorspace');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testPaletteIsCMYKIfCMYKImage()
+     */
     public function testPaletteIsCMYKIfCMYKImage()
     {
         $this->markTestSkipped('GD driver does not recognize CMYK images properly');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testGetColorAtCMYK()
+     */
     public function testGetColorAtCMYK()
     {
         $this->markTestSkipped('GD driver does not recognize CMYK images properly');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testChangeColorSpaceAndStripImage()
+     */
     public function testChangeColorSpaceAndStripImage()
     {
         $this->markTestSkipped('GD driver does not support ICC profiles');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testStripImageWithInvalidProfile()
+     */
     public function testStripImageWithInvalidProfile()
     {
         $this->markTestSkipped('GD driver does not support ICC profiles');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testStripGBRImageHasGoodColors()
+     */
     public function testStripGBRImageHasGoodColors()
     {
         $this->markTestSkipped('GD driver does not support ICC profiles');
@@ -100,11 +149,6 @@ class ImageTest extends AbstractImageTest
     protected function getImagine()
     {
         return new Imagine();
-    }
-
-    protected function supportMultipleLayers()
-    {
-        return false;
     }
 
     public function testRotateWithNoBackgroundColor()
@@ -118,18 +162,53 @@ class ImageTest extends AbstractImageTest
     }
 
     /**
+     * @group always-skipped
+     *
      * @dataProvider provideVariousSources
      *
-     * @param mixed $source
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testResolutionOnSave()
      */
     public function testResolutionOnSave($source)
     {
         $this->markTestSkipped('GD driver only supports 72 dpi resolution');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testJpegSamplingFactors()
+     */
     public function testJpegSamplingFactors()
     {
         $this->markTestSkipped('GD driver does not support JPEG sampling factors');
+    }
+
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testCountAMultiLayeredImage()
+     */
+    public function testCountAMultiLayeredImage()
+    {
+        $this->markTestSkipped('GD driver does not support multiple layers');
+    }
+
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testResizeAnimatedGifResizeResult()
+     */
+    public function testResizeAnimatedGifResizeResult()
+    {
+        $this->markTestSkipped('GD driver does not support multiple layers');
     }
 
     protected function getImageResolution(ImageInterface $image)

--- a/tests/Imagine/Test/Gd/LayersTest.php
+++ b/tests/Imagine/Test/Gd/LayersTest.php
@@ -71,31 +71,50 @@ class LayersTest extends AbstractLayersTest
         $this->assertTrue($layers->has(0));
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testLayerArrayAccessInvalidArgumentExceptions()
+     */
     public function testLayerArrayAccessInvalidArgumentExceptions($offset = null)
     {
         $this->markTestSkipped('GD driver does not fully support layers array access');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testLayerArrayAccessOutOfBoundsExceptions()
+     */
     public function testLayerArrayAccessOutOfBoundsExceptions($offset = null)
     {
         $this->markTestSkipped('GD driver does not fully support layers array access');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testAnimateEmpty()
+     */
     public function testAnimateEmpty()
     {
         $this->markTestSkipped('GD driver does not support animated gifs');
     }
 
-    public function testAnimateLoaded()
-    {
-        $this->markTestSkipped('GD driver does not support animated gifs');
-    }
-
     /**
+     * @group always-skipped
+     *
      * @dataProvider provideAnimationParameters
      *
-     * @param mixed $delay
-     * @param mixed $loops
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testAnimateWithParameters()
      */
     public function testAnimateWithParameters($delay, $loops)
     {
@@ -103,10 +122,13 @@ class LayersTest extends AbstractLayersTest
     }
 
     /**
+     * @group always-skipped
+     *
      * @dataProvider provideAnimationParameters
      *
-     * @param mixed $delay
-     * @param mixed $loops
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testAnimateWithWrongParameters()
      */
     public function testAnimateWithWrongParameters($delay, $loops)
     {

--- a/tests/Imagine/Test/Gmagick/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Gmagick/ClassFactoryTest.php
@@ -15,7 +15,7 @@ use Imagine\Gmagick\Imagine;
 use Imagine\Test\Factory\AbstractClassFactoryTest;
 
 /**
- * @group ext-gd
+ * @group ext-gmagick
  */
 class ClassFactoryTest extends AbstractClassFactoryTest
 {

--- a/tests/Imagine/Test/Gmagick/ImageTest.php
+++ b/tests/Imagine/Test/Gmagick/ImageTest.php
@@ -57,47 +57,72 @@ class ImageTest extends AbstractImageTest
         );
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testPaletteIsGrayIfGrayImage()
+     */
     public function testPaletteIsGrayIfGrayImage()
     {
         $this->markTestSkipped('Gmagick does not support Gray colorspace, because of the lack omg image type support');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testGetColorAtCMYK()
+     */
     public function testGetColorAtCMYK()
     {
         $this->markTestSkipped('Gmagick fails to read CMYK colors properly, see https://bugs.php.net/bug.php?id=67435');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testImageCreatedAlpha()
+     */
     public function testImageCreatedAlpha()
     {
         $this->markTestSkipped('Alpha transparency is not supported by Gmagick');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::testFillAlphaPrecision()
+     */
     public function testFillAlphaPrecision()
     {
         $this->markTestSkipped('Alpha transparency is not supported by Gmagick');
     }
 
     /**
-     * @dataProvider pasteWithAlphaProvider
+     * Alpha transparency is not supported by Gmagick.
      *
-     * @param int $alpha
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImageTest::pasteWithAlphaProvider()
      */
-    public function testPasteWithAlpha($alpha)
+    public function pasteWithAlphaProvider()
     {
-        if ($alpha > 0 && $alpha < 100) {
-            $this->markTestSkipped('Alpha transparency is not supported by Gmagick');
-        }
-        parent::testPasteWithAlpha($alpha);
+        return array(
+            array(0),
+            array(100),
+        );
     }
 
     protected function getImagine()
     {
         return new Imagine();
-    }
-
-    protected function supportMultipleLayers()
-    {
-        return true;
     }
 
     protected function getImageResolution(ImageInterface $image)

--- a/tests/Imagine/Test/Gmagick/ImagineTest.php
+++ b/tests/Imagine/Test/Gmagick/ImagineTest.php
@@ -29,6 +29,13 @@ class ImagineTest extends AbstractImagineTest
         }
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractImagineTest::testCreateAlphaPrecision()
+     */
     public function testCreateAlphaPrecision()
     {
         $this->markTestSkipped('Alpha transparency is not supported by Gmagick');

--- a/tests/Imagine/Test/Gmagick/LayersTest.php
+++ b/tests/Imagine/Test/Gmagick/LayersTest.php
@@ -69,6 +69,13 @@ class LayersTest extends AbstractLayersTest
         }
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\AbstractLayersTest::testAnimateEmpty()
+     */
     public function testAnimateEmpty()
     {
         $this->markTestSkipped('Animate empty is skipped due to https://bugs.php.net/bug.php?id=62309');

--- a/tests/Imagine/Test/Image/AbstractImageTest.php
+++ b/tests/Imagine/Test/Image/AbstractImageTest.php
@@ -597,10 +597,6 @@ abstract class AbstractImageTest extends ImagineTestCase
 
     public function testCountAMultiLayeredImage()
     {
-        if (!$this->supportMultipleLayers()) {
-            $this->markTestSkipped('This driver does not support multiple layers');
-        }
-
         $this->assertGreaterThan(1, count($this->getMultiLayeredImage()->layers()));
     }
 
@@ -714,10 +710,6 @@ abstract class AbstractImageTest extends ImagineTestCase
      */
     public function testResizeAnimatedGifResizeResult()
     {
-        if (!$this->supportMultipleLayers()) {
-            $this->markTestSkipped('This driver does not support multiple layers');
-        }
-
         $imagine = $this->getImagine();
 
         $image = $imagine->open('tests/Imagine/Fixtures/anima.gif');
@@ -953,11 +945,6 @@ abstract class AbstractImageTest extends ImagineTestCase
      * @return \Imagine\Image\ImagineInterface
      */
     abstract protected function getImagine();
-
-    /**
-     * @return bool
-     */
-    abstract protected function supportMultipleLayers();
 
     /**
      * @param ImageInterface $image

--- a/tests/Imagine/Test/Image/Palette/CMYKTest.php
+++ b/tests/Imagine/Test/Image/Palette/CMYKTest.php
@@ -36,6 +36,13 @@ class CMYKTest extends AbstractPaletteTest
         );
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\Palette\AbstractPaletteTest::testColorWithDifferentAlphasAreNotSame()
+     */
     public function testColorWithDifferentAlphasAreNotSame($color = null, $alpha = null)
     {
         $this->markTestSkipped('CMYK color does not support alpha');

--- a/tests/Imagine/Test/Image/Palette/Color/CMYKTest.php
+++ b/tests/Imagine/Test/Image/Palette/Color/CMYKTest.php
@@ -32,11 +32,25 @@ class CMYKTest extends AbstractColorTest
         );
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\Palette\Color\AbstractColorTest::testIsNotOpaque()
+     */
     public function testIsNotOpaque($color = null)
     {
         $this->markTestSkipped('CMYK color does not support alpha');
     }
 
+    /**
+     * @group always-skipped
+     *
+     * {@inheritdoc}
+     *
+     * @see \Imagine\Test\Image\Palette\Color\AbstractColorTest::provideNotOpaqueColors()
+     */
     public function provideNotOpaqueColors()
     {
         $this->markTestSkipped('CMYK color does not support alpha');

--- a/tests/Imagine/Test/Imagick/ClassFactoryTest.php
+++ b/tests/Imagine/Test/Imagick/ClassFactoryTest.php
@@ -15,7 +15,7 @@ use Imagine\Imagick\Imagine;
 use Imagine\Test\Factory\AbstractClassFactoryTest;
 
 /**
- * @group ext-gd
+ * @group ext-imagick
  */
 class ClassFactoryTest extends AbstractClassFactoryTest
 {

--- a/tests/Imagine/Test/Imagick/ImageTest.php
+++ b/tests/Imagine/Test/Imagick/ImageTest.php
@@ -141,11 +141,6 @@ class ImageTest extends AbstractImageTest
         unlink('tests/Imagine/Fixtures/crop/anima3-topleft-actual.gif');
     }
 
-    protected function supportMultipleLayers()
-    {
-        return true;
-    }
-
     protected function getImageResolution(ImageInterface $image)
     {
         return $image->getImagick()->getImageResolution();


### PR DESCRIPTION
Let's keep the phpunit output as clean as possible, to highlight actual stuff we should take care of.