### PR TITLE
Allow using "codestyle" composer command to fix coding style

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,6 +22,7 @@ return PhpCsFixer\Config::create()
     ->setCacheFile(__DIR__ . '/.php_cs.cache')
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
+        ->exclude('cache')
         ->in(__DIR__)
     )
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
     set -o errexit
     case "${TRAVISOPERATION:-}" in
         codestyle)
-            composer --no-interaction codestyle
+            composer --no-interaction codestyle -- --no-interaction --dry-run --diff -- .
             ;;
         *)
             composer --no-interaction test -- --exclude-group "${PHPUNIT_EXCLUDED_GROUPS}"

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,6 @@
     },
     "scripts": {
         "test": "simple-phpunit --verbose",
-        "codestyle": "php-cs-fixer fix --path-mode=intersection --config=.php_cs.dist --dry-run --diff --no-interaction -- ."
+        "codestyle": "php-cs-fixer fix --path-mode=intersection --config=.php_cs.dist"
     }
 }


### PR DESCRIPTION
Sample usage:

```bash
composer codestyle -- path/to/file.php
```