### PR TITLE
Avoid assigning palette in Gmagick\Image::usePalette

### DIFF
--- a/src/Gmagick/Image.php
+++ b/src/Gmagick/Image.php
@@ -752,7 +752,6 @@ final class Image extends AbstractImage
             $this->profile($palette->profile());
 
             $this->setColorspace($palette);
-            $this->palette = $palette;
         } catch (\GmagickException $e) {
             throw new RuntimeException('Failed to set colorspace', $e->getCode(), $e);
         }


### PR DESCRIPTION
This is already done by Gmagick\Image::setColorspace()