### PR TITLE
Automatic release announcements for Imagine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Imagine
-[![Travis CI Build Status](https://travis-ci.org/avalanche123/Imagine.svg?branch=develop)](https://travis-ci.org/avalanche123/Imagine) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/avalanche123/Imagine?branch=develop&svg=true)](https://ci.appveyor.com/project/avalanche123/Imagine)
+[![Travis CI Build Status](https://travis-ci.org/avalanche123/Imagine.svg?branch=develop)](https://travis-ci.org/avalanche123/Imagine) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/avalanche123/Imagine?branch=develop&svg=true)](https://ci.appveyor.com/project/avalanche123/Imagine) [![Release Notes](https://release-notes.com/badges/v2.svg)](https://release-notes.com/@open-source-community/avalanche123-Imagine)
 
 Tweet about it using the [#php_imagine](https://twitter.com/search?q=%23php_imagine) hashtag.
 


### PR DESCRIPTION
Ahoi @avalanche123,

this PR adds a release notes badge to your `README.md`.

I'm the maintainer of that open source [release notes hub](/release-notes/release-notes-hub), where you can publish and subscribe to open source release announcements.
I set up a release page for [Imagine](https://release-notes.com/@open-source-community/avalanche123-Imagine) that gets automatically updated with your `CHANGELOG.md` file and broadcasts release announcements to subscribers.

I hope you find it useful and i did not bother you.

Cheerio,
Alrik
