### PR TITLE
Allows for extra metadata sections to be read

### DIFF
--- a/src/Image/Metadata/ExifMetadataReader.php
+++ b/src/Image/Metadata/ExifMetadataReader.php
@@ -115,14 +115,10 @@ class ExifMetadataReader extends AbstractMetadataReader
         }
 
         $metadata = array();
-        $sources = array('EXIF' => 'exif', 'IFD0' => 'ifd0');
 
-        foreach ($sources as $name => $prefix) {
-            if (!isset($exifData[$name])) {
-                continue;
-            }
-            foreach ($exifData[$name] as $prop => $value) {
-                $metadata[$prefix . '.' . $prop] = $value;
+        foreach ($exifData as $name => $values) {
+            foreach ($values as $prop => $value) {
+                $metadata[strtolower($name) . '.' . $prop] = $value;
             }
         }
 


### PR DESCRIPTION
By setting them in the `ExifMetadataReader` constructor.

Fixes #568.