### PR TITLE
Fix undefined method error with older PHP versions

### DIFF
--- a/src/Gd/Drawer.php
+++ b/src/Gd/Drawer.php
@@ -140,7 +140,9 @@ final class Drawer implements DrawerInterface
         if ($thickness === 0 && !$fill) {
             return $this;
         }
-        imageantialias($this->resource, true);
+        if (function_exists('imageantialias')) {
+            imageantialias($this->resource, true);
+        }
         imagesetthickness($this->resource, $thickness);
 
         if ($fill) {
@@ -149,12 +151,16 @@ final class Drawer implements DrawerInterface
             $callback = 'imageellipse';
         }
 
-        imageantialias($this->resource, true);
+        if (function_exists('imageantialias')) {
+            imageantialias($this->resource, true);
+        }
         if (false === imagealphablending($this->resource, true)) {
             throw new RuntimeException('Draw ellipse operation failed');
         }
 
-        imageantialias($this->resource, true);
+        if (function_exists('imageantialias')) {
+            imageantialias($this->resource, true);
+        }
         if (false === $callback($this->resource, $center->getX(), $center->getY(), $size->getWidth(), $size->getHeight(), $this->getColor($color))) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw ellipse operation failed');


### PR DESCRIPTION
The `imageantialias` is generally available after PHP 7.2.0. For versions before that, this check is needed.