### PR TITLE
feature - more information in RuntimeException

### DIFF
--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -11,9 +11,21 @@
 
 namespace Imagine\Exception;
 
+use Throwable;
+
 /**
  * Imagine-specific runtime exception.
  */
 class RuntimeException extends \RuntimeException implements Exception
 {
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        $lastError = error_get_last();
+        $message = isset($lastError['message'])
+            ? sprintf('%s (last PHP runtime error message: %s)', $message, $lastError['message'])
+            : $message
+        ;
+
+        parent::__construct($message, $code, $previous);
+    }
 }


### PR DESCRIPTION
porposal of error_get_last usage for having more verbose error messages in RuntimeException

see [>this issue#1167<](https://github.com/liip/LiipImagineBundle/issues/1167) encountered while using LiipImagineBundle in a SF4 app 