### PR TITLE
Fixes #715: Silenced call to \Imagick::setImageOpacity() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ### NEXT (YYYY-MM-DD)
-
+* Silence call to `\Imagick::setImageOpacity()` in order to prevent deprecation error with PECL 3.4.4 and ImageMagick 6 (#715, @samdark)
 
 ### 1.2.0 (2018-12-07)
 * `ExifMetadataReader` now returns all the available metadata, not only EXIF and IFD0 (#701, @mlocati)

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -106,7 +106,7 @@ final class Imagine extends AbstractImagine
                 if (method_exists($imagick, 'setImageAlpha')) {
                     $imagick->setImageAlpha($pixel->getColorValue(\Imagick::COLOR_ALPHA));
                 } else {
-                    $imagick->setImageOpacity($pixel->getColorValue(\Imagick::COLOR_ALPHA));
+                    @$imagick->setImageOpacity($pixel->getColorValue(\Imagick::COLOR_ALPHA));
                 }
             }
 

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -108,7 +108,7 @@ final class Imagine extends AbstractImagine
                 if (method_exists($imagick, 'setImageAlpha')) {
                     $imagick->setImageAlpha($pixel->getColorValue(\Imagick::COLOR_ALPHA));
                 } else {
-                    $this->withExceptionHandler(function () use ($imagick) {
+                    $this->withExceptionHandler(function () use ($imagick, $pixel) {
                         $imagick->setImageOpacity($pixel->getColorValue(\Imagick::COLOR_ALPHA));
                     });
                 }

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -133,24 +133,11 @@ final class Imagine extends AbstractImagine
     private function withExceptionHandler($callback)
     {
         set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            if (0 === error_reporting()) {
-                return;
-            }
-
-            throw new RuntimeException($errstr, $errno, new \ErrorException($errstr, 0, $errno, $errfile, $errline));
-        }, E_WARNING | E_NOTICE);
-        $exception = null;
-        try {
-            $callback();
-        } catch (Exception $x) {
-            $exception = $x;
-        } catch (Throwable $x) {
-            $exception = $x;
-        }
+            // ignore deprecation errors
+            return;
+        }, E_DEPRECATED);
+        $callback();
         restore_error_handler();
-        if ($exception !== null) {
-            throw $exception;
-        }
     }
 
     /**

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -11,7 +11,6 @@
 
 namespace Imagine\Imagick;
 
-use Exception;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\RuntimeException;
@@ -24,7 +23,6 @@ use Imagine\Image\Palette\CMYK;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\Palette\Grayscale;
 use Imagine\Image\Palette\RGB;
-use Throwable;
 
 /**
  * Imagine implementation using the Imagick PHP extension.
@@ -132,9 +130,8 @@ final class Imagine extends AbstractImagine
      */
     private function withExceptionHandler($callback)
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+        set_error_handler(function () {
             // ignore deprecation errors
-            return;
         }, E_DEPRECATED);
         $callback();
         restore_error_handler();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,13 @@ if (version_compare(PHPUnit\Runner\Version::id(), '7') >= 0) {
     class_alias('Imagine\Test\Constraint\Constraint_v1', 'Imagine\Test\Constraint\Constraint');
 }
 
+if (!class_exists('PHPUnit\Framework\Error\Deprecated')) {
+    class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
+}
+
+// Do not convert deprecation warnings to exceptions so silencing them works
+\PHPUnit\Framework\Error\Deprecated::$enabled = false;
+
 define('IMAGINE_TEST_SRCFOLDER', dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src');
 
 define('IMAGINE_TEST_FIXTURESFOLDER', __DIR__ . DIRECTORY_SEPARATOR . 'fixtures');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,13 +42,6 @@ if (version_compare(PHPUnit\Runner\Version::id(), '7') >= 0) {
     class_alias('Imagine\Test\Constraint\Constraint_v1', 'Imagine\Test\Constraint\Constraint');
 }
 
-if (!class_exists('PHPUnit\Framework\Error\Deprecated')) {
-    class_alias('PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated');
-}
-
-// Do not convert deprecation warnings to exceptions so silencing them works
-\PHPUnit\Framework\Error\Deprecated::$enabled = false;
-
 define('IMAGINE_TEST_SRCFOLDER', dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src');
 
 define('IMAGINE_TEST_FIXTURESFOLDER', __DIR__ . DIRECTORY_SEPARATOR . 'fixtures');


### PR DESCRIPTION
In order to prevent deprecation error with PECL 3.4.4 and ImageMagick 6.

See #715