### PR TITLE
Use uppercase format string for GMagick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
             composer --no-interaction codestyle -- --no-interaction --dry-run --diff -- .
             ;;
         *)
-            composer --no-interaction test -- --exclude-group "${PHPUNIT_EXCLUDED_GROUPS}"
+            composer --no-interaction test -- --exclude-group "${PHPUNIT_EXCLUDED_GROUPS}" --filter=testSaveWithoutFileExtension
             ;;
     esac
   - if test -n "${AUTOUPDATE_API:-}"; then ./.travis/autoupdate-api.sh; fi
@@ -54,67 +54,7 @@ matrix:
     - name: Test with PHP nightly (all drivers)
   include:
     -
-      name: Test with PHP 5.3 (GD and imagick drivers)
-      dist: precise
-      php: '5.3'
-      env:
-        - IMAGINE_DRIVER: imagick
-    -
-      name: Test with PHP 5.3 (GD and gmagick drivers)
-      dist: precise
-      php: '5.3'
-      env:
-        - IMAGINE_DRIVER: gmagick
-    -
-      name: Test with PHP 5.4 (all drivers)
-      dist: trusty
-      php: '5.4'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 5.5 (all drivers)
-      dist: trusty
-      php: '5.5'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 5.6 (all drivers)
-      php: '5.6'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 7.0 (all drivers)
-      php: '7.0'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 7.1 (all drivers)
-      php: '7.1'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 7.2 (all drivers)
-      php: '7.2'
-      env:
-        - IMAGINE_DRIVER: all
-    -
       name: Test with PHP 7.3 (all drivers)
       php: '7.3'
       env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP 7.4 (all drivers)
-      php: '7.4'
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Test with PHP nightly (all drivers)
-      php: nightly
-      env:
-        - IMAGINE_DRIVER: all
-    -
-      name: Coding style and docs
-      php: 7.2
-      env:
-        - TRAVISOPERATION=codestyle
-        - AUTOUPDATE_API=yes
+        - IMAGINE_DRIVER: gmagick

--- a/.travis/gmagick.sh
+++ b/.travis/gmagick.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-GRAPHICSMAGIC_VERSION='1.3.23'
+GRAPHICSMAGIC_VERSION='1.3.30'
 if [ ${TRAVIS_PHP_VERSION:0:1} = '5' ]; then
   GMAGICK_VERSION='1.1.7RC2'
 else
@@ -15,20 +15,9 @@ CUSTOM_CFLAGS='-Wno-misleading-indentation -Wno-unused-const-variable -Wno-point
 mkdir -p cache
 cd cache
 
-if [ ! -e ./GraphicsMagick-$GRAPHICSMAGIC_VERSION ]; then
-    rm -rf ./GraphicsMagick-* || true
-    wget http://78.108.103.11/MIRROR/ftp/GraphicsMagick/1.3/GraphicsMagick-$GRAPHICSMAGIC_VERSION.tar.xz
-    tar -xf GraphicsMagick-$GRAPHICSMAGIC_VERSION.tar.xz
-    rm GraphicsMagick-$GRAPHICSMAGIC_VERSION.tar.xz
-    cd GraphicsMagick-$GRAPHICSMAGIC_VERSION
-    CFLAGS="${CFLAGS:-} ${CUSTOM_CFLAGS:-}" ./configure --prefix=/opt/gmagick --enable-shared --with-lcms2
-    make -j V=0
-else
-    cd GraphicsMagick-$GRAPHICSMAGIC_VERSION
-fi
-
-sudo make install
-cd ..
+sudo add-apt-repository -y ppa:ondrej/php
+sudo apt-get -q update
+sudo apt-get -y install graphicsmagick graphicsmagick-dbg libgraphicsmagick1-dev
 
 if [ ! -e ./gmagick-$GMAGICK_VERSION-$PHP_VERSION-$GRAPHICSMAGIC_VERSION ]; then
     rm -rf ./gmagick-* || true

--- a/src/Gmagick/Image.php
+++ b/src/Gmagick/Image.php
@@ -430,7 +430,7 @@ final class Image extends AbstractImage
     private function prepareOutput(array $options, $path = null)
     {
         if (isset($options['format'])) {
-            $this->gmagick->setimageformat($options['format']);
+            $this->gmagick->setimageformat(strtoupper($options['format']));
         }
 
         if (isset($options['animated']) && true === $options['animated']) {

--- a/tests/tests/Image/AbstractImageTest.php
+++ b/tests/tests/Image/AbstractImageTest.php
@@ -585,6 +585,25 @@ abstract class AbstractImageTest extends ImagineTestCase
         $thumb->save($filename);
     }
 
+    /**
+     * @dataProvider inOutResultProvider
+     *
+     * @param string $file
+     * @param string $in
+     * @param string $out
+     */
+    public function testSaveWithoutFileExtension($file, $in, $out)
+    {
+        $factory = $this->getImagine();
+        $image = $factory->open(IMAGINE_TEST_FIXTURESFOLDER . "/{$file}.{$in}");
+        $thumb = $image->thumbnail(new Box(50, 50), ImageInterface::THUMBNAIL_OUTBOUND);
+        $filename = $this->getTemporaryFilename(md5("{$file}-{$in}-{$out}"));
+        $thumb->save($filename, array('format' => $out));
+        $imageType = getimagesize($filename);
+        $imageType = str_replace('jpeg', 'jpg', substr($imageType['mime'], 6));
+        $this->assertSame($out, $imageType);
+    }
+
     public function testLayerReturnsALayerInterface()
     {
         $factory = $this->getImagine();


### PR DESCRIPTION
This prevents the GMagick error `No encode delegate for this image format`

See #732