### PR TITLE
Fix IMagick rotation canvas size

### DIFF
--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -312,7 +312,11 @@ final class Image extends AbstractImage
         try {
             $pixel = $this->getColor($background);
 
-            $this->imagick->rotateimage($pixel, $angle);
+            $imageWidth = $this->imagick->getImageWidth();
+            $imageHeight = $this->imagick->getImageHeight();
+
+            $this->imagick->rotateImage($pixel, $angle);
+            $this->imagick->setImagePage($imageWidth, $imageHeight, 0, 0);
 
             $pixel->clear();
             $pixel->destroy();

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -312,11 +312,8 @@ final class Image extends AbstractImage
         try {
             $pixel = $this->getColor($background);
 
-            $imageWidth = $this->imagick->getImageWidth();
-            $imageHeight = $this->imagick->getImageHeight();
-
-            $this->imagick->rotateImage($pixel, $angle);
-            $this->imagick->setImagePage($imageWidth, $imageHeight, 0, 0);
+            $this->imagick->rotateimage($pixel, $angle);
+            $this->imagick->setImagePage(0, 0, 0, 0);
 
             $pixel->clear();
             $pixel->destroy();

--- a/tests/tests/Image/AbstractImageTest.php
+++ b/tests/tests/Image/AbstractImageTest.php
@@ -219,6 +219,18 @@ abstract class AbstractImageTest extends ImagineTestCase
         $this->assertSame(0, $color->getAlpha());
     }
 
+    public function testRotateWithCrop()
+    {
+        $palette = new RGB();
+        $color = $this
+            ->getImagine()
+            ->create(new Box(100, 100), $palette->color('#f00'))
+            ->rotate(45, $palette->color('#fff'))
+            ->crop(new Point(0, 0), new Box(100, 100))
+            ->getColorAt(new Point(0, 50));
+        $this->assertSame('#ffffff', (string) $color);
+    }
+
     /**
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
This is a followup pull request to #712 (#709)

I included @lashus commit from the original PR in 2a8e9e637ee137eb692beb10adb16d25ea1b89cd