### PR TITLE
Read Exif data from local files directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4",
-        "friendsofphp/php-cs-fixer": "2.2.*"
+        "friendsofphp/php-cs-fixer": "^2.2"
     },
     "suggest": {
         "ext-gd": "to use the GD implementation",

--- a/src/Image/Metadata/ExifMetadataReader.php
+++ b/src/Image/Metadata/ExifMetadataReader.php
@@ -71,6 +71,10 @@ class ExifMetadataReader extends AbstractMetadataReader
     {
         $loader = $file instanceof LoaderInterface ? $file : new Loader($file);
 
+        if ($loader->isLocalFile()) {
+            return $this->extract($loader->getPath());
+        }
+
         return $this->doReadData($loader->getData());
     }
 


### PR DESCRIPTION
Reading the file data into memory is not needed for local files. This reduces memory consumption in ExifMetadataReader.