### PR TITLE
Use uppercase format string to prevent no encode delegate error

### DIFF
--- a/src/Gmagick/Image.php
+++ b/src/Gmagick/Image.php
@@ -447,7 +447,7 @@ final class Image extends AbstractImage
             $this->flatten();
         }
         if (isset($options['format'])) {
-            $this->gmagick->setimageformat($options['format']);
+            $this->gmagick->setimageformat(strtoupper($options['format']));
         }
     }
 


### PR DESCRIPTION
Fixes #732 as discussed in https://github.com/avalanche123/Imagine/pull/747#issuecomment-721372830