### PR TITLE
Try-catch in Imagine\Gmagick\Effects::convolve should catch GmagickException instead of ImagickException

### DIFF
--- a/src/Gmagick/Effects.php
+++ b/src/Gmagick/Effects.php
@@ -82,7 +82,7 @@ class Effects implements EffectsInterface
     public function grayscale()
     {
         try {
-            $this->gmagick->setImageType(2);
+            $this->gmagick->setimagetype(2);
         } catch (\GmagickException $e) {
             throw new RuntimeException('Failed to grayscale the image', $e->getCode(), $e);
         }
@@ -118,7 +118,7 @@ class Effects implements EffectsInterface
     public function blur($sigma = 1)
     {
         try {
-            $this->gmagick->blurImage(0, $sigma);
+            $this->gmagick->blurimage(0, $sigma);
         } catch (\GmagickException $e) {
             throw new RuntimeException('Failed to blur the image', $e->getCode(), $e);
         }
@@ -168,7 +168,7 @@ class Effects implements EffectsInterface
         }
         try {
             $this->gmagick->convolveimage($matrix->getValueList());
-        } catch (\ImagickException $e) {
+        } catch (\GmagickException $e) {
             throw new RuntimeException('Failed to convolve the image');
         }
 

--- a/tests/tests/Gmagick/EffectsTest.php
+++ b/tests/tests/Gmagick/EffectsTest.php
@@ -40,7 +40,7 @@ class EffectsTest extends AbstractEffectsTest
      */
     public function testColorize()
     {
-        $this->isGoingToThrowException('Imagine\Exception\RuntimeException');
+        $this->isGoingToThrowException('Imagine\Exception\NotSupportedException');
         parent::testColorize();
     }
 


### PR DESCRIPTION
1) Try-catch in Imagine\Gmagick\Effects::convolve should catch GmagickException instead of ImagickException.
2) Changed the case of the Gmagick methods calls to lowercase to match their declarations.
3) Imagine\Test\Gmagick\EffectsTest::testColorize now expects more specific NotSupportedException instead of rather common RuntimeException.

Main reason of this pull-request is 1), it is small bugfix.
I know that tests wanted, but I'm not sure that it is required in such case because looks like its copy-paste mistake.
I tested code using the following test:
in \Imagine\Test\Gmagick\EffectsTest add

```php
public function testConvolutionFailed()
{
    $image = $this->getImagine()->create(new \Imagine\Image\Box(1, 1));
    $matrix = new \Imagine\Utils\Matrix(3, 3, array(
        0, 0.5, 0,
        0.5, 1, 0.5,
        0, 0.5, 0,
    ));

    $this->isGoingToThrowException('Imagine\Exception\RuntimeException');
    $image->effects()->convolve($matrix);
}
```

then run

```sh
./vendor/bin/phpunit tests/tests/Gmagick/EffectsTest.php
```

Image is too small and it leads to exception. At least for
gmagick version 2.0.4RC1
GraphicsMagick version GraphicsMagick 1.3.28 2018-01-20 Q16
I'm not sure about other versions. But if gmagick will throw an exception it should be GmagickException.
