### PR TITLE
remove final from drivers

### DIFF
--- a/src/Gd/Imagine.php
+++ b/src/Gd/Imagine.php
@@ -26,8 +26,10 @@ use Imagine\Utils\ErrorHandling;
 
 /**
  * Imagine implementation using the GD library.
+ *
+ * @final
  */
-final class Imagine extends AbstractImagine
+class Imagine extends AbstractImagine
 {
     /**
      * Initialize the class.

--- a/src/Gmagick/Imagine.php
+++ b/src/Gmagick/Imagine.php
@@ -27,6 +27,8 @@ use Imagine\Image\Palette\RGB;
 
 /**
  * Imagine implementation using the Gmagick PHP extension.
+ *
+ * @final
  */
 class Imagine extends AbstractImagine
 {

--- a/src/Imagick/Imagine.php
+++ b/src/Imagick/Imagine.php
@@ -27,8 +27,10 @@ use Imagine\Utils\ErrorHandling;
 
 /**
  * Imagine implementation using the Imagick PHP extension.
+ *
+ * @final
  */
-final class Imagine extends AbstractImagine
+class Imagine extends AbstractImagine
 {
     /**
      * @throws \Imagine\Exception\RuntimeException


### PR DESCRIPTION
Hello,

When coupled with `liip/imagine-bundle`, these classes can be set as lazy in symfony since they aren't necessary until resolving is needed. 