### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/src/Gd/Drawer.php
+++ b/src/Gd/Drawer.php
@@ -331,7 +331,11 @@ final class Drawer implements DrawerInterface
             throw new RuntimeException('Draw polygon operation failed');
         }
 
-        if (false === $callback($this->resource, $points, count($coordinates), $this->getColor($color))) {
+        if (false === (
+            PHP_VERSION_ID < 80000
+                ? $callback($this->resource, $points, count($coordinates), $this->getColor($color))
+                : $callback($this->resource, $points, $this->getColor($color))
+        )) {
             imagealphablending($this->resource, false);
             throw new RuntimeException('Draw polygon operation failed');
         }

--- a/src/Gd/Layers.php
+++ b/src/Gd/Layers.php
@@ -94,6 +94,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::current()
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->getClassFactory()->createImage(ClassFactoryInterface::HANDLE_GD, $this->resource, $this->palette, new MetadataBag());
@@ -104,6 +105,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::key()
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->offset;
@@ -114,6 +116,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::next()
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->offset;
@@ -124,6 +127,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::rewind()
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->offset = 0;
@@ -134,6 +138,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::valid()
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offset < 1;
@@ -144,6 +149,7 @@ class Layers extends AbstractLayers
      *
      * @see \Countable::count()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return 1;
@@ -154,6 +160,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetExists()
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return 0 === $offset;
@@ -164,6 +171,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetGet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (0 === $offset) {
@@ -178,6 +186,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetSet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new NotSupportedException('GD does not support layer set');
@@ -188,6 +197,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetUnset()
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new NotSupportedException('GD does not support layer unset');

--- a/src/Gmagick/Layers.php
+++ b/src/Gmagick/Layers.php
@@ -130,6 +130,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::current()
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->extractAt($this->offset);
@@ -163,6 +164,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::key()
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->offset;
@@ -173,6 +175,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::next()
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->offset;
@@ -183,6 +186,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::rewind()
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->offset = 0;
@@ -193,6 +197,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::valid()
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offset < count($this);
@@ -203,6 +208,7 @@ class Layers extends AbstractLayers
      *
      * @see \Countable::count()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         try {
@@ -217,6 +223,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetExists()
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return is_int($offset) && $offset >= 0 && $offset < count($this);
@@ -227,6 +234,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetGet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->extractAt($offset);
@@ -237,6 +245,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetSet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $image)
     {
         if (!$image instanceof Image) {
@@ -290,6 +299,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetUnset()
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         try {

--- a/src/Image/Histogram/Bucket.php
+++ b/src/Image/Histogram/Bucket.php
@@ -53,6 +53,7 @@ final class Bucket implements \Countable
     /**
      * @return int the number of elements in the bucket
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->count;

--- a/src/Image/Metadata/MetadataBag.php
+++ b/src/Image/Metadata/MetadataBag.php
@@ -47,6 +47,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \Countable::count()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -57,6 +58,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \IteratorAggregate::getIterator()
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
@@ -67,6 +69,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \ArrayAccess::offsetExists()
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->data);
@@ -77,6 +80,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \ArrayAccess::offsetSet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->data[$offset] = $value;
@@ -87,6 +91,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \ArrayAccess::offsetUnset()
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);
@@ -97,6 +102,7 @@ class MetadataBag implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @see \ArrayAccess::offsetGet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);

--- a/src/Imagick/Layers.php
+++ b/src/Imagick/Layers.php
@@ -141,6 +141,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::current()
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->extractAt($this->offset);
@@ -174,6 +175,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::key()
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->offset;
@@ -184,6 +186,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::next()
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->offset;
@@ -194,6 +197,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::rewind()
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->offset = 0;
@@ -204,6 +208,7 @@ class Layers extends AbstractLayers
      *
      * @see \Iterator::valid()
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offset < count($this);
@@ -214,6 +219,7 @@ class Layers extends AbstractLayers
      *
      * @see \Countable::count()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         try {
@@ -228,6 +234,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetExists()
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return is_int($offset) && $offset >= 0 && $offset < count($this);
@@ -238,6 +245,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetGet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->extractAt($offset);
@@ -248,6 +256,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetSet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $image)
     {
         if (!$image instanceof Image) {
@@ -290,6 +299,7 @@ class Layers extends AbstractLayers
      *
      * @see \ArrayAccess::offsetUnset()
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         try {


### PR DESCRIPTION
Fixes the PHP 8.1 deprecations of:

1. https://wiki.php.net/rfc/internal_method_return_types
2. https://wiki.php.net/rfc/deprecations_php_8_1#num_points_parameter_of_image_open_filled_polygon

We should probably wait with merging this until an RC version of PHP 8.1 was released.