### PR TITLE
Let PHP automatically detect the preferred TLS version

### DIFF
--- a/src/File/Loader.php
+++ b/src/File/Loader.php
@@ -264,17 +264,6 @@ class Loader implements LoaderInterface
         if (!@curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true)) {
             throw new RuntimeException('curl_setopt(CURLOPT_FOLLOWLOCATION) failed.');
         }
-        if (defined('CURL_SSLVERSION_TLSv1_1')) {
-            if (!@curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1)) {
-                throw new RuntimeException('curl_setopt(CURLOPT_SSLVERSION) failed.');
-            }
-        } else {
-            // Manually checked that CURL_SSLVERSION_TLSv1_1 is 5 for any version of curl from 7.34.0 to 7.61.0
-            // See for example https://github.com/curl/curl/blob/curl-7_34_0/include/curl/curl.h#L1668
-            if (!@curl_setopt($curl, CURLOPT_SSLVERSION, 5)) {
-                throw new RuntimeException('curl_setopt(CURLOPT_SSLVERSION) failed.');
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
<!--
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.0RC3
Configuration: /app/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 770 (  8%)
.......................S.S.S....S.....S........................ 126 / 770 ( 16%)
......................SS....................................... 189 / 770 ( 24%)
..............S..............S..SS..S.SS....SS.....SS.......... 252 / 770 ( 32%)
...........SS.................SSSSSSSSSSSSSSS.................. 315 / 770 ( 40%)
............................................................... 378 / 770 ( 49%)
............................................................... 441 / 770 ( 57%)
............................................................... 504 / 770 ( 65%)
............................................................... 567 / 770 ( 73%)
............................................................... 630 / 770 ( 81%)
............................................................... 693 / 770 ( 90%)
.........................SSS.............
Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\resource" to suppress this warning in /app/vendor/phpunit/phpunit/src/Framework/MockObject/MockClass.php(51) : eval()'d code on line 75

Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\resource" to suppress this warning in /app/vendor/phpunit/phpunit/src/Framework/MockObject/MockClass.php(51) : eval()'d code on line 867

Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\resource" to suppress this warning in /app/vendor/phpunit/phpunit/src/Framework/MockObject/MockClass.php(51) : eval()'d code on line 889

Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\resource" to suppress this warning in /app/vendor/phpunit/phpunit/src/Framework/MockObject/MockClass.php(51) : eval()'d code on line 3637
...................... 756 / 770 ( 98%)
..............                                                  770 / 770 (100%)

Time: 02:44.850, Memory: 38.00 MB

There were 38 skipped tests:

1) Imagine\Test\Gd\DrawerTest::testChord with data set #1 (0, true)
The GD Drawer can NOT draw correctly filled chords

/app/tests/tests/Draw/AbstractDrawerTest.php:79

2) Imagine\Test\Gd\DrawerTest::testChord with data set #3 (1, true)
The GD Drawer can NOT draw correctly filled chords

/app/tests/tests/Draw/AbstractDrawerTest.php:79

3) Imagine\Test\Gd\DrawerTest::testChord with data set #5 (4, true)
The GD Drawer can NOT draw correctly filled chords

/app/tests/tests/Draw/AbstractDrawerTest.php:79

4) Imagine\Test\Gd\DrawerTest::testCircle with data set #4 (4, false)
The GD Drawer can NOT draw correctly not filled circles with a thickness greater than 1

/app/tests/tests/Draw/AbstractDrawerTest.php:105

5) Imagine\Test\Gd\DrawerTest::testEllipse with data set #4 (4, false)
The GD Drawer can NOT draw correctly not filled ellipses with a thickness greater than 1

/app/tests/tests/Draw/AbstractDrawerTest.php:131

6) Imagine\Test\Gd\ImageTest::testPaletteIsCMYKIfCMYKImage
GD driver only supports RGB colors

/app/tests/tests/Image/AbstractImageTest.php:63

7) Imagine\Test\Gd\ImageTest::testPaletteIsGrayIfGrayImage
GD driver only supports RGB colors

/app/tests/tests/Image/AbstractImageTest.php:75

8) Imagine\Test\Gd\ImageTest::testImageResolutionChange
GD driver does not support exporting images with custom resolutions

/app/tests/tests/Image/AbstractImageTest.php:620

9) Imagine\Test\Gd\ImageTest::testCountAMultiLayeredImage
GD does not support layer sets

/app/tests/tests/Image/AbstractImageTest.php:700

10) Imagine\Test\Gd\ImageTest::testChangeColorSpaceAndStripImage
GD driver does not support color profiles

/app/tests/tests/Image/AbstractImageTest.php:726

11) Imagine\Test\Gd\ImageTest::testStripImageWithInvalidProfile
GD driver does not support color profiles

/app/tests/tests/Image/AbstractImageTest.php:744

12) Imagine\Test\Gd\ImageTest::testGetColorAtCMYK
GD driver only supports RGB colors

/app/tests/tests/Image/AbstractImageTest.php:786

13) Imagine\Test\Gd\ImageTest::testStripGBRImageHasGoodColors
GD driver does not support color profiles

/app/tests/tests/Image/AbstractImageTest.php:817

14) Imagine\Test\Gd\ImageTest::testResizeAnimatedGifResizeResult
GD does not support layer sets

/app/tests/tests/Image/AbstractImageTest.php:840

15) Imagine\Test\Gd\ImageTest::testResolutionOnSave with data set #0 ('/app/tests/fixtures/example.svg')
GD driver does not support exporting images with custom resolutions

/app/tests/tests/Image/AbstractImageTest.php:937

16) Imagine\Test\Gd\ImageTest::testResolutionOnSave with data set #1 ('/app/tests/fixtures/100-perce...ck.png')
GD driver does not support exporting images with custom resolutions

/app/tests/tests/Image/AbstractImageTest.php:937

17) Imagine\Test\Gd\ImageTest::testJpegSamplingFactors with data set #0 (array(1, 1, 1), array(1, 1, 1))
The GD driver does not support JPEG sampling factors

/app/tests/tests/Image/AbstractImageTest.php:1035

18) Imagine\Test\Gd\ImageTest::testJpegSamplingFactors with data set #1 (array(2, 1, 1), array(2, 1, 1))
The GD driver does not support JPEG sampling factors

/app/tests/tests/Image/AbstractImageTest.php:1035

19) Imagine\Test\Gd\ImagineTest::testShouldOpenAHeicImage
This driver can't open HEIC images

/app/tests/tests/Image/AbstractImagineTest.php:95

20) Imagine\Test\Gd\ImagineTest::testShouldOpenAJxlImage
This driver can't open JXL images

/app/tests/tests/Image/AbstractImagineTest.php:112

21) Imagine\Test\Gd\LayersTest::testLayerArrayAccessInvalidArgumentExceptions with data set #0 ('lambda')
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:151

22) Imagine\Test\Gd\LayersTest::testLayerArrayAccessInvalidArgumentExceptions with data set #1 ('0')
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:151

23) Imagine\Test\Gd\LayersTest::testLayerArrayAccessInvalidArgumentExceptions with data set #2 ('1')
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:151

24) Imagine\Test\Gd\LayersTest::testLayerArrayAccessInvalidArgumentExceptions with data set #3 (1.0)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:151

25) Imagine\Test\Gd\LayersTest::testLayerArrayAccessOutOfBoundsExceptions with data set #0 (-1)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:173

26) Imagine\Test\Gd\LayersTest::testLayerArrayAccessOutOfBoundsExceptions with data set #1 (2)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:173

27) Imagine\Test\Gd\LayersTest::testAnimateEmpty
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:190

28) Imagine\Test\Gd\LayersTest::testAnimateWithParameters with data set #0 (0, 0)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:218

29) Imagine\Test\Gd\LayersTest::testAnimateWithParameters with data set #1 (500, 0)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:218

30) Imagine\Test\Gd\LayersTest::testAnimateWithParameters with data set #2 (0, 10)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:218

31) Imagine\Test\Gd\LayersTest::testAnimateWithParameters with data set #3 (5000, 10)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:218

32) Imagine\Test\Gd\LayersTest::testAnimateWithWrongParameters with data set #0 (-1, 0)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:257

33) Imagine\Test\Gd\LayersTest::testAnimateWithWrongParameters with data set #1 (500, -1)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:257

34) Imagine\Test\Gd\LayersTest::testAnimateWithWrongParameters with data set #2 (-1, 10)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:257

35) Imagine\Test\Gd\LayersTest::testAnimateWithWrongParameters with data set #3 (0, -1)
GD does not support layer sets

/app/tests/tests/Image/AbstractLayersTest.php:257

36) Imagine\Test\Imagick\ImagineTest::testShouldOpenAAvifImage
This driver can't open AVIF images

/app/tests/tests/Image/AbstractImagineTest.php:78

37) Imagine\Test\Imagick\ImagineTest::testShouldOpenAHeicImage
This driver can't open HEIC images

/app/tests/tests/Image/AbstractImagineTest.php:95

38) Imagine\Test\Imagick\ImagineTest::testShouldOpenAJxlImage
This driver can't open JXL images

/app/tests/tests/Image/AbstractImagineTest.php:112

OK, but incomplete, skipped, or risky tests!
Tests: 770, Assertions: 1524, Skipped: 38.
PLEASE INCLUDE A TEST FOR THIS PULL REQUEST.
PULL REQUESTS NOT COVERED BY TEST CASES WILL TAKE MUCH MORE TIME TO BE REVIEWED.

In case of bug fixes, the correct approach to submit a pull request is:
1. write a test case that shows the problem (tests should fail)
2. submit the pull request
3. update the pull request with a fix for the bug
-->
PHP recommends:
Your best bet is to not set this and let it use the default. Setting it to 2 or 3 is very dangerous given the known vulnerabilities in SSLv2 and SSLv3.
https://www.php.net/manual/en/function.curl-setopt.php