### PR TITLE
Preserve alpha channel in Imagick negative effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ### NEXT (YYYY-MM-DD)
+- Fix the Imagick driver inverting the alpha channel in `effects()->negative()` (an opaque image became fully transparent); it now excludes the alpha channel, matching the GD driver
 
 ### 1.5.2 (2026-01-09)
 - Do not call curl_close on PHP 8.0+ (#875, @dmaicher)

--- a/src/Imagick/Effects.php
+++ b/src/Imagick/Effects.php
@@ -75,7 +75,10 @@ class Effects implements EffectsInterface, InfoProvider
     public function negative()
     {
         try {
-            $this->imagick->negateImage(false, \Imagick::CHANNEL_ALL);
+            // \Imagick::CHANNEL_ALL includes the alpha channel, so a plain negateImage()
+            // call would invert transparency along with the color (an opaque image would
+            // become fully transparent). Exclude the alpha channel to match the GD driver.
+            $this->imagick->negateImage(false, \Imagick::CHANNEL_ALL & ~\Imagick::CHANNEL_ALPHA);
         } catch (\ImagickException $e) {
             throw new RuntimeException('Failed to negate the image', $e->getCode(), $e);
         }

--- a/tests/tests/Effects/AbstractEffectsTest.php
+++ b/tests/tests/Effects/AbstractEffectsTest.php
@@ -46,6 +46,27 @@ abstract class AbstractEffectsTest extends ImagineTestCase implements InfoProvid
         $this->assertEquals('#ffff00', (string) $image->getColorAt(new Point(10, 10)));
     }
 
+    public function testNegatePreservesAlpha()
+    {
+        if (!$this->getDriverInfo()->hasFeature(Info::FEATURE_NEGATEIMAGE)) {
+            $this->isGoingToThrowException('Imagine\Exception\NotSupportedException');
+        }
+        $palette = new RGB();
+        $imagine = $this->getImagine();
+
+        // Negating must invert the color channels only, not the alpha channel:
+        // a fully-opaque image must remain fully opaque (see the Imagick driver,
+        // where CHANNEL_ALL used to invert the alpha and turn the image transparent).
+        $image = $imagine->create(new Box(20, 20), $palette->color('ff0'));
+        $image->effects()
+            ->negative();
+
+        $pixel = $image->getColorAt(new Point(10, 10));
+
+        $this->assertEquals('#0000ff', (string) $pixel);
+        $this->assertSame(100, $pixel->getAlpha());
+    }
+
     public function testGamma()
     {
         $palette = new RGB();


### PR DESCRIPTION
`effects()->negative()` on the Imagick driver inverts the alpha channel as well as the colours, which GD doesn't do. Result: an opaque image comes back fully transparent. The colour values are right, you just can't see them.

Cause is `negateImage(false, \Imagick::CHANNEL_ALL)`. `CHANNEL_ALL` includes alpha, so opaque alpha flips to transparent. GD avoids this because `IMG_FILTER_NEGATE` only touches colour.

Fix is to negate with `CHANNEL_ALL & ~CHANNEL_ALPHA` so only the colour channels flip (same thing intervention/image does). The Gmagick driver doesn't need it: in the gd-gmagick docker image `CHANNEL_ALL` leaves an opaque image opaque, and Gmagick's CHANNEL constants are sequential enum values rather than bitmasks, so the `& ~` trick wouldn't apply anyway.

Added `testNegatePreservesAlpha` to `AbstractEffectsTest` so every driver gets covered. It negates a fully-opaque image and asserts it stays opaque. Fails on Imagick before the fix (alpha 100 to 0), passes after. Verified the full suite green in both the gd-imagick and gd-gmagick docker images.
