### PR TITLE
Fix imagick stale layers

### DIFF
--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -126,6 +126,20 @@ final class Image extends AbstractImage implements InfoProvider
     }
 
     /**
+     * Replaces the underlying \Imagick instance, invalidating the cached
+     * layers (if any) since they wrap the replaced instance.
+     *
+     * @param \Imagick $imagick
+     */
+    private function setImagick(\Imagick $imagick)
+    {
+        if ($imagick !== $this->imagick) {
+            $this->imagick = $imagick;
+            $this->layers = null;
+        }
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see \Imagine\Image\ManipulatorInterface::copy()
@@ -152,13 +166,13 @@ final class Image extends AbstractImage implements InfoProvider
         try {
             if ($this->layers()->count() > 1) {
                 // Crop each layer separately
-                $this->imagick = $this->imagick->coalesceImages();
+                $this->setImagick($this->imagick->coalesceImages());
                 foreach ($this->imagick as $frame) {
                     $frame->cropImage($size->getWidth(), $size->getHeight(), $start->getX(), $start->getY());
                     // Reset canvas for gif format
                     $frame->setImagePage(0, 0, 0, 0);
                 }
-                $this->imagick = $this->imagick->deconstructImages();
+                $this->setImagick($this->imagick->deconstructImages());
             } else {
                 $this->imagick->cropImage($size->getWidth(), $size->getHeight(), $start->getX(), $start->getY());
                 // Reset canvas for gif format
@@ -284,11 +298,11 @@ final class Image extends AbstractImage implements InfoProvider
     {
         try {
             if ($this->layers()->count() > 1) {
-                $this->imagick = $this->imagick->coalesceImages();
+                $this->setImagick($this->imagick->coalesceImages());
                 foreach ($this->imagick as $frame) {
                     $frame->resizeImage($size->getWidth(), $size->getHeight(), $this->getFilter($filter), 1);
                 }
-                $this->imagick = $this->imagick->deconstructImages();
+                $this->setImagick($this->imagick->deconstructImages());
             } else {
                 $this->imagick->resizeImage($size->getWidth(), $size->getHeight(), $this->getFilter($filter), 1);
             }
@@ -425,7 +439,7 @@ final class Image extends AbstractImage implements InfoProvider
         } else {
             $this->layers()->merge();
         }
-        $this->imagick = $this->applyImageOptions($this->imagick, $options, $path);
+        $this->setImagick($this->applyImageOptions($this->imagick, $options, $path));
 
         // flatten only if image has multiple layers
         if ((!isset($options['flatten']) || $options['flatten'] === true) && $this->layers()->count() > 1) {
@@ -739,9 +753,9 @@ final class Image extends AbstractImage implements InfoProvider
         // @see https://github.com/mkoppanen/imagick/issues/45
         try {
             if (method_exists($this->imagick, 'mergeImageLayers') && defined('Imagick::LAYERMETHOD_UNDEFINED')) {
-                $this->imagick = $this->imagick->mergeImageLayers(\Imagick::LAYERMETHOD_UNDEFINED);
+                $this->setImagick($this->imagick->mergeImageLayers(\Imagick::LAYERMETHOD_UNDEFINED));
             } elseif (method_exists($this->imagick, 'flattenImages')) {
-                $this->imagick = $this->imagick->flattenImages();
+                $this->setImagick($this->imagick->flattenImages());
             }
         } catch (\ImagickException $e) {
             throw new RuntimeException('Flatten operation failed', $e->getCode(), $e);

--- a/tests/tests/Imagick/ImageTest.php
+++ b/tests/tests/Imagick/ImageTest.php
@@ -143,6 +143,49 @@ class ImageTest extends AbstractImageTest
         );
     }
 
+    public function testLayersReflectResizedFramesAfterResize()
+    {
+        $imagine = $this->getImagine();
+        $image = $imagine->open(IMAGINE_TEST_FIXTURESFOLDER . '/anima.gif');
+        $image->resize(new Box(59, 75));
+        $layers = $image->layers();
+        $this->assertCount(3, $layers);
+        $layers->coalesce();
+        foreach ($layers as $index => $frame) {
+            $this->assertEquals(new Box(59, 75), $frame->getSize(), sprintf('Frame %d should have the resized size', $index));
+        }
+    }
+
+    public function testLayersReflectCroppedFramesAfterCrop()
+    {
+        $imagine = $this->getImagine();
+        $image = $imagine->open(IMAGINE_TEST_FIXTURESFOLDER . '/anima.gif');
+        // Crop inside the region where the animation frames actually differ,
+        // so that deconstructImages() keeps all the frames
+        $image->crop(new Point(110, 70), new Box(50, 40));
+        $layers = $image->layers();
+        $this->assertCount(3, $layers);
+        $layers->coalesce();
+        foreach ($layers as $index => $frame) {
+            $this->assertEquals(new Box(50, 40), $frame->getSize(), sprintf('Frame %d should have the cropped size', $index));
+        }
+    }
+
+    public function testAnimatedDelayAndLoopsAreAppliedAfterResize()
+    {
+        $imagine = $this->getImagine();
+        $image = $imagine->open(IMAGINE_TEST_FIXTURESFOLDER . '/anima.gif');
+        $image->resize(new Box(59, 75));
+        $filename = $this->getTemporaryFilename('.gif');
+        $image->save($filename, array('animated' => true, 'animated.delay' => 500, 'animated.loops' => 3));
+        $imagick = new \Imagick($filename);
+        $delay = $imagick->getImageDelay();
+        $iterations = $imagick->getImageIterations();
+        $imagick->clear();
+        $this->assertSame(50, $delay);
+        $this->assertSame(3, $iterations);
+    }
+
     public function testOptimize()
     {
         $imagine = $this->getImagine();


### PR DESCRIPTION
Resize an animated GIF on the Imagick driver, then ask for its layers: you get the pre-resize frames back.

```php
$image = $imagine->open('animated.gif'); // 2 frames, 8x8
$image->resize(new Box(4, 4));

$image->getSize()->getWidth();                                // 4
$image->layers()->coalesce()->get(0)->getSize()->getWidth();  // 8, expected 4
```

`Layers` grabs the `\Imagick` instance in its constructor, and `Image::layers()` caches the object forever. That was harmless until the multi-frame paths started swapping the instance: `coalesceImages()`/`deconstructImages()` return a new `\Imagick`, which `resize()`, `crop()`, `flatten()` and the `optimize` save path assign to `$this->imagick`, so the cached `Layers` keeps reading frames nothing else uses anymore. One concrete casualty: `animated.delay`/`animated.loops` are applied through `layers()` in `prepareOutput()`, land on the orphaned frames, and the saved file keeps its original timing.

Reassignments now go through a small setter that drops the cached `Layers` when the instance changes (`__clone()` already rebuilds it the same way), so the next `layers()` call reads the live resource.
