### PR TITLE
Preserve transparency in the Imagick grayscale effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ### NEXT (YYYY-MM-DD)
+- Fix the Imagick driver deactivating the alpha channel in `effects()->grayscale()` (transparent pixels were encoded as opaque gray); it now uses the alpha-preserving grayscale image type, like `usePalette()` (#880, @nlemoine)
 
 ### 1.5.3 (2026-06-03)
 - Fix the Imagick driver painting a "black box" when pasting an image with transparent areas at an alpha lower than 100; the opacity now scales the existing per-pixel alpha instead of overwriting it (#878, @nlemoine)

--- a/src/Imagick/Effects.php
+++ b/src/Imagick/Effects.php
@@ -95,7 +95,20 @@ class Effects implements EffectsInterface, InfoProvider
     {
         static::getDriverInfo()->requireFeature(DriverInfo::FEATURE_GRAYSCALEEFFECT);
         try {
-            $this->imagick->setImageType(\Imagick::IMGTYPE_GRAYSCALE);
+            // IMGTYPE_GRAYSCALE is an alpha-less image type: ImageMagick deactivates the alpha
+            // channel when switching to it, so transparent pixels would be encoded as opaque
+            // gray. Use the alpha-preserving variant instead, as Image::setColorspace() already
+            // does (the constant was named IMGTYPE_GRAYSCALEMATTE before ImageMagick 7 / Imagick
+            // 3.4.3, and some combinations of Imagick and ImageMagick versions define neither,
+            // hence the hard-coded fallback value).
+            if (defined('\Imagick::IMGTYPE_GRAYSCALEALPHA')) {
+                $grayscaleType = \Imagick::IMGTYPE_GRAYSCALEALPHA;
+            } elseif (defined('\Imagick::IMGTYPE_GRAYSCALEMATTE')) {
+                $grayscaleType = \Imagick::IMGTYPE_GRAYSCALEMATTE;
+            } else {
+                $grayscaleType = 3;
+            }
+            $this->imagick->setImageType($grayscaleType);
         } catch (\ImagickException $e) {
             throw new RuntimeException('Failed to grayscale the image', $e->getCode(), $e);
         }

--- a/tests/tests/Effects/AbstractEffectsTest.php
+++ b/tests/tests/Effects/AbstractEffectsTest.php
@@ -13,6 +13,7 @@ namespace Imagine\Test\Effects;
 
 use Imagine\Driver\Info;
 use Imagine\Driver\InfoProvider;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\RGB;
 use Imagine\Image\Point;
@@ -115,6 +116,35 @@ abstract class AbstractEffectsTest extends ImagineTestCase implements InfoProvid
         $this->assertEquals($greyR, $greyG);
         $this->assertEquals($greyR, $greyB);
         $this->assertEquals($greyG, $greyB);
+    }
+
+    public function testGrayscalePreservesTransparency()
+    {
+        if (!$this->getDriverInfo()->hasFeature(Info::FEATURE_GRAYSCALEEFFECT)) {
+            $this->isGoingToThrowException('Imagine\Exception\NotSupportedException');
+        } else {
+            try {
+                $this->getDriverInfo()->requireFeature(Info::FEATURE_TRANSPARENCY);
+            } catch (NotSupportedException $x) {
+                $this->markTestSkipped($x->getMessage());
+            }
+        }
+        $palette = new RGB();
+        $imagine = $this->getImagine();
+
+        // Grayscaling must desaturate the color channels without dropping the
+        // alpha channel (on the Imagick driver, IMGTYPE_GRAYSCALE used to
+        // deactivate it, so every transparent pixel was encoded as opaque gray).
+        // The image is saved and reloaded because the defect only shows at
+        // encode time: in-memory pixel reads still expose the stored alpha.
+        $image = $imagine->create(new Box(20, 20), $palette->color('f00', 0));
+        $image->effects()
+            ->grayscale();
+
+        $reloaded = $imagine->load($image->get('png'));
+        $pixel = $reloaded->getColorAt(new Point(10, 10));
+
+        $this->assertSame(0, $pixel->getAlpha());
     }
 
     public function brightnessProvider()


### PR DESCRIPTION
`$image->effects()->grayscale()` on the Imagick driver turns transparent pixels into opaque gray. `Imagick::IMGTYPE_GRAYSCALE` is one of ImageMagick's alpha-less image types, and switching to it deactivates the image's alpha channel (`getImageAlphaChannel()` flips from `true` to `false`). The pixels keep their stored alpha values in memory — only the encoders ignore them — so the breakage only surfaces in the saved file, whatever the format. That's also why the test asserts through an encode/decode roundtrip instead of reading pixels in place.

The driver already solves this exact problem in `Image::setColorspace()`, where `usePalette()` with a grayscale palette deliberately lands on `IMGTYPE_GRAYSCALEALPHA` to keep alpha; `effects()->grayscale()` just never got the same treatment. It now picks its type through the same fallback chain (`IMGTYPE_GRAYSCALEALPHA` on ImageMagick 7 / Imagick 3.4.3+, `IMGTYPE_GRAYSCALEMATTE` before, hard-coded `3` when neither constant exists). The gray rendition is unchanged — both types go through the same colorspace transform, only the alpha trait differs — so the existing `testGrayscale` expectations still hold.

GD is unaffected (`IMG_FILTER_GRAYSCALE` preserves alpha), and Gmagick doesn't support transparency at all, so the shared test skips there.
