### PR TITLE
Preserve a transparent base when pasting with alpha on the GD driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Fix the GD driver washing a transparent destination into an opaque block when pasting an image at an alpha lower than 100; the opacity now scales the overlay's per-pixel alpha and composites alpha-aware instead of routing through `imagecopymerge()` (#XXX, @nlemoine)
+
 ### 1.5.4 (2026-06-04)
 - Fix imagick stale layers (#879, @nlemoine)
 - Fix the Imagick driver deactivating the alpha channel in `effects()->grayscale()` (transparent pixels were encoded as opaque gray); it now uses the alpha-preserving grayscale image type, like `usePalette()` (#880, @nlemoine)

--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -188,7 +188,29 @@ final class Image extends AbstractImage implements InfoProvider
                 throw new RuntimeException('Image paste operation failed');
             }
         } elseif ($alpha > 0) {
-            if (imagecopymerge(/*dst_im*/$this->resource, /*src_im*/ $image->resource, /*dst_x*/ $start->getX(), /*dst_y*/ $start->getY(), /*src_x*/ 0, /*src_y*/ 0, /*src_w*/ $size->getWidth(), /*src_h*/ $size->getHeight(), /*pct*/ $alpha) === false) {
+            // Fade the overlay's own alpha channel by the opacity factor, then
+            // paste it at full opacity through the alpha-aware imagecopy() path.
+            // Routing partial alpha through imagecopymerge() instead ignores the
+            // source's per-pixel alpha and resolves every touched destination
+            // pixel as fully opaque, which washes a transparent base into an
+            // opaque block. Mirrors Imagick\Image::paste().
+            $overlay = clone $image;
+
+            imagealphablending($overlay->resource, false);
+            for ($x = 0, $width = $size->getWidth(); $x < $width; $x++) {
+                for ($y = 0, $height = $size->getHeight(); $y < $height; $y++) {
+                    $rgba = imagecolorat($overlay->resource, $x, $y);
+                    $currentAlpha = ($rgba >> 24) & 0x7F;
+                    $fadedAlpha = 127 - (int) round((127 - $currentAlpha) * $alpha / 100);
+                    imagesetpixel($overlay->resource, $x, $y, ($rgba & 0xFFFFFF) | ($fadedAlpha << 24));
+                }
+            }
+
+            imagealphablending($this->resource, true);
+            $success = imagecopy($this->resource, $overlay->resource, $start->getX(), $start->getY(), 0, 0, $size->getWidth(), $size->getHeight());
+            imagealphablending($this->resource, false);
+
+            if ($success === false) {
                 throw new RuntimeException('Image paste operation failed');
             }
         }

--- a/tests/tests/Image/AbstractImageTest.php
+++ b/tests/tests/Image/AbstractImageTest.php
@@ -1125,6 +1125,52 @@ abstract class AbstractImageTest extends ImagineTestCase implements InfoProvider
         $this->assertColorSimilar($palette->color(array(128, 0, 128)), $centre, 'opaque area was not blended', 2);
     }
 
+    /**
+     * Companion to testPasteWithAlphaPreservesTransparency for the case where
+     * the *destination* has transparency. Pasting an overlay at an alpha lower
+     * than 100 over a transparent base must keep the base transparent: opacity
+     * has to scale the overlay's per-pixel alpha and composite alpha-aware. The
+     * GD driver used to route this through imagecopymerge(), which ignores the
+     * source alpha and forces every touched destination pixel fully opaque,
+     * washing a transparent base into an opaque block.
+     */
+    public function testPasteWithAlphaPreservesTransparentBase()
+    {
+        try {
+            $this->getDriverInfo()->requireFeature(Info::FEATURE_TRANSPARENCY);
+        } catch (NotSupportedException $x) {
+            $this->markTestSkipped($x->getMessage());
+        }
+        $palette = new RGB();
+        $imagine = $this->getImagine();
+
+        // Destination: a fully-transparent canvas.
+        $destination = $imagine->create(new Box(20, 20), $palette->color(array(255, 255, 255), 0));
+
+        // Overlay: an opaque green square pasted over the top-left corner.
+        $overlay = $imagine->create(new Box(10, 10), $palette->color(array(0, 128, 0)));
+
+        try {
+            $destination->paste($overlay, new Point(0, 0), 40);
+        } catch (NotSupportedException $x) {
+            // e.g. Gmagick, which does not support pasting with alpha.
+            $this->markTestSkipped($x->getMessage());
+        }
+
+        // The area the overlay does not cover stays fully transparent.
+        $gap = $destination->getColorAt(new Point(15, 15));
+        $this->assertSame(0, $gap->getAlpha(), 'area outside the overlay must stay transparent');
+
+        // Under the overlay the base takes the overlay colour at ~40% opacity,
+        // NOT a fully-opaque block. The bug produced alpha=100 here (and washed
+        // the colour towards the base's stored RGB).
+        $covered = $destination->getColorAt(new Point(5, 5));
+        $this->assertColorSimilar($palette->color(array(0, 128, 0)), $covered, 'overlay colour was not preserved under the paste', 2, false);
+        $coveredAlpha = $covered->getAlpha();
+        $this->assertLessThan(100, $coveredAlpha, 'the transparent base was forced fully opaque (imagecopymerge ignores the source alpha)');
+        $this->assertTrue(abs($coveredAlpha - 40) <= 2, 'overlay opacity should scale the alpha to ~40%, got ' . $coveredAlpha);
+    }
+
     public function testPasteOutOfBoundaries()
     {
         $imagine = $this->getImagine();


### PR DESCRIPTION
GD counterpart of #878, which fixed the same thing for Imagick. Found it while pasting a watermark over a transparent PNG.

Problem: `Gd\Image::paste($image, $start, $alpha)` sends `0 < alpha < 100` through `imagecopymerge()`. That function only reads the source RGB (it ignores the source per-pixel alpha), and every destination pixel it touches ends up opaque. So when the base has transparency, the area under the overlay is forced opaque and its color gets pulled towards whatever RGB the transparent base stored, which is white for a normal PNG. You end up with an opaque near-white block where the paste happened. An opaque base (a JPEG) is fine, it only breaks when the base itself has transparency.

Minimal repro:

```php
use Imagine\Gd\Imagine;
use Imagine\Image\Box;
use Imagine\Image\Point;
use Imagine\Image\Palette\RGB;

$imagine = new Imagine();
$palette = new RGB();

$base = $imagine->create(new Box(20, 20), $palette->color([255, 255, 255], 0)); // transparent
$overlay = $imagine->create(new Box(10, 10), $palette->color([0, 128, 0]));      // opaque green
$base->paste($overlay, new Point(0, 0), 40);

$base->getColorAt(new Point(5, 5));
// before: #99cc99, alpha 100  (opaque, washed towards white)
// after:  #008000, alpha 40   (overlay color at 40%, base stays semi-transparent)
```

Fix: fade the overlay's own alpha channel by the opacity factor, then paste at full opacity so it goes through the alpha-aware `imagecopy()` path instead of `imagecopymerge()`. I clone the overlay first so the caller's image is left untouched. Same approach as #878 did for Imagick (`evaluateImage(MULTIPLY, factor, CHANNEL_ALPHA)` then composite), and as intervention/image#1489 did for GD. GD has no native equivalent of Imagick's `evaluateImage()` on the alpha channel, so the overlay alpha is scaled pixel by pixel.

Opaque bases behave exactly as before, `testPasteWithAlpha` and `testPasteWithAlphaPreservesTransparency` still pass with the same values.

Testing: I added `testPasteWithAlphaPreservesTransparentBase` next to the existing opaque-base test, in `AbstractImageTest` so every driver runs it. It fails on GD before the change, passes on Imagick, and is skipped on Gmagick (no alpha paste there). Full suite is green in the `8.1-gd-imagick` docker image (GD bundled 2.1 compatible), 783 tests, and I also ran it against a newer GD (2.3.3) locally.
